### PR TITLE
fix usage of deprecated `intllib.Getter()`

### DIFF
--- a/mods/lordlib/init.lua
+++ b/mods/lordlib/init.lua
@@ -9,7 +9,7 @@ lord.load("signals.lua")
 
 function lord.require_intllib()
 	if minetest.global_exists("intllib") then
-		return intllib.Getter()
+		return intllib.make_gettext_pair()
 	else
 		return function(q) return q end
 	end

--- a/mods/mobs/api.lua
+++ b/mods/mobs/api.lua
@@ -8,7 +8,7 @@ mobs.mod = "redo"
 local S
 
 if minetest.get_modpath("intllib") then
-	S = intllib.Getter()
+	S = intllib.make_gettext_pair()
 else
 	S = function(s, a, ...) a = {a, ...}
 		return s:gsub("@(%d+)", function(n)

--- a/mods/technic_chests/register.lua
+++ b/mods/technic_chests/register.lua
@@ -1,4 +1,4 @@
-local S = rawget(_G, "intllib") and intllib.Getter() or function(s) return s end
+local S = lord.require_intllib()
 
 local pipeworks = rawget(_G, "pipeworks")
 if not minetest.get_modpath("pipeworks") then


### PR DESCRIPTION
closes #127 