### PR TITLE
Ошибка в алиасе мифрилового болта - пофикшено

### DIFF
--- a/mods/legacy/init.lua
+++ b/mods/legacy/init.lua
@@ -242,7 +242,7 @@ lord.mod_loaded()
 minetest.register_alias("lottthrowing:arrow", "arrows:arrow_steel")
 minetest.register_alias("lottthrowing:arrow_mithril", "arrows:arrow_mithril")
 minetest.register_alias("lottthrowing:bolt", "arrows:bolt_steel")
-minetest.register_alias("lottthrowing:bolt_mithril", "arrows:bol_mithril")
+minetest.register_alias("lottthrowing:bolt_mithril", "arrows:bolt_mithril")
 
 minetest.register_alias("lottthrowing:axe_dwarf", "arrows:axe_dwarf")
 minetest.register_alias("lottthrowing:axe_elf", "arrows:axe_elf")


### PR DESCRIPTION
Была допущена ошибка в алиасе болта, из-за чего старые мифриловые болты на сервере обозначались как "unknown item"
![image](https://user-images.githubusercontent.com/22934348/52172994-92f70b00-27ad-11e9-9523-480ed0f68341.png)
