### PR TITLE
Replace nodeupdate(pos) using with minetest.check_for_falling(pos)

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -366,7 +366,7 @@ minetest.register_abm({
 			end
 			-- Remove node
 			minetest.remove_node(p0)
-			nodeupdate(p0)
+			minetest.check_for_falling(p0)
 		end
 	end
 })


### PR DESCRIPTION
nodeupdate in deprecated and removed in 5.0.0. 