### PR TITLE
 Update MTG/default: upd nodes.lua, functions.lua & trees.lua

### DIFF
--- a/mods/_lott/lottmapgen/nodes.lua
+++ b/mods/_lott/lottmapgen/nodes.lua
@@ -185,7 +185,7 @@ minetest.register_node("lottmapgen:dunland_grass", {
 	description = SL("Dunland Grass"),
 	tiles = {"lottmapgen_dunland_grass.png", "default_dirt.png", {name = "default_dirt.png^lottmapgen_dunland_grass_side.png", tileable_vertical = false}},
 	is_ground_content = true,
-	groups = {crumbly=3,soil=1, not_in_creative_inventory =1,lottmapgen_grass=1},
+	groups = {crumbly=3,soil=1, not_in_creative_inventory =1,grass=1,spreading_dirt_type=1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name="default_grass_footstep", gain=0.25},
@@ -196,7 +196,7 @@ minetest.register_node("lottmapgen:ironhill_grass", {
 	description = SL("Iron Hills Grass"),
 	tiles = {"lottmapgen_dunland_grass.png", "default_dirt.png", {name =  "default_dirt.png^lottmapgen_dunland_grass_side.png", tileable_vertical = false}},
 	is_ground_content = true,
-	groups = {crumbly=3,soil=1, not_in_creative_inventory =1,lottmapgen_grass=1},
+	groups = {crumbly=3,soil=1, not_in_creative_inventory =1,grass=1,spreading_dirt_type=1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name="default_grass_footstep", gain=0.25},
@@ -207,7 +207,7 @@ minetest.register_node("lottmapgen:gondor_grass", {
 	description = SL("Gondor Grass"),
 	tiles = {"default_grass.png", "default_dirt.png", {name = "default_dirt.png^default_grass_side.png", tileable_vertical = false}},
 	is_ground_content = true,
-	groups = {crumbly=3,soil=1, not_in_creative_inventory =1,lottmapgen_grass=1},
+	groups = {crumbly=3,soil=1, not_in_creative_inventory =1,grass=1,spreading_dirt_type=1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name="default_grass_footstep", gain=0.25},
@@ -218,7 +218,7 @@ minetest.register_node("lottmapgen:lorien_grass", {
 	description = SL("Lorien Grass"),
 	tiles = {"lottmapgen_lorien_grass.png", "default_dirt.png", {name =  "default_dirt.png^lottmapgen_lorien_grass_side.png", tileable_vertical = false}},
 	is_ground_content = true,
-	groups = {crumbly=3,soil=1, not_in_creative_inventory =1,lottmapgen_grass=1},
+	groups = {crumbly=3,soil=1, not_in_creative_inventory =1,grass=1,spreading_dirt_type=1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name="default_grass_footstep", gain=0.25},
@@ -229,7 +229,7 @@ minetest.register_node("lottmapgen:fangorn_grass", {
 	description = SL("Fangorn Grass"),
 	tiles = {"default_grass.png", "default_dirt.png", {name = "default_dirt.png^default_grass_side.png", tileable_vertical = false}},
 	is_ground_content = true,
-	groups = {crumbly=3,soil=1, not_in_creative_inventory =1,lottmapgen_grass=1},
+	groups = {crumbly=3,soil=1, not_in_creative_inventory =1,grass=1,spreading_dirt_type=1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name="default_grass_footstep", gain=0.25},
@@ -240,7 +240,7 @@ minetest.register_node("lottmapgen:mirkwood_grass", {
 	description = SL("Mirkwood Grass"),
 	tiles = {"lottmapgen_mirkwood_grass.png", "default_dirt.png", {name =  "default_dirt.png^lottmapgen_mirkwood_grass_side.png", tileable_vertical = false}},
 	is_ground_content = true,
-	groups = {crumbly=3,soil=1, not_in_creative_inventory =1,lottmapgen_grass=1},
+	groups = {crumbly=3,soil=1, not_in_creative_inventory =1,grass=1,spreading_dirt_type=1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name="default_grass_footstep", gain=0.25},
@@ -251,7 +251,7 @@ minetest.register_node("lottmapgen:rohan_grass", {
 	description = SL("Rohan Grass"),
 	tiles = {"lottmapgen_rohan_grass.png", "default_dirt.png", {name =  "default_dirt.png^lottmapgen_rohan_grass_side.png", tileable_vertical = false}},
 	is_ground_content = true,
-	groups = {crumbly=3,soil=1, not_in_creative_inventory =1,lottmapgen_grass=1},
+	groups = {crumbly=3,soil=1, not_in_creative_inventory =1,grass=1,spreading_dirt_type=1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name="default_grass_footstep", gain=0.25},
@@ -262,7 +262,7 @@ minetest.register_node("lottmapgen:shire_grass", {
 	description = SL("Shire Grass"),
 	tiles = {"lottmapgen_shire_grass.png", "default_dirt.png", {name =  "default_dirt.png^lottmapgen_shire_grass_side.png", tileable_vertical = false}},
 	is_ground_content = true,
-	groups = {crumbly=3,soil=1, lottmapgen_grass=1, not_in_creative_inventory =1},
+	groups = {crumbly=3,soil=1, grass=1, not_in_creative_inventory=1,spreading_dirt_type=1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name="default_grass_footstep", gain=0.25},
@@ -273,7 +273,7 @@ minetest.register_node("lottmapgen:ithilien_grass", {
 	description = SL("Ithilien Grass"),
 	tiles = {"default_grass.png", "default_dirt.png", {name = "default_dirt.png^default_grass_side.png", tileable_vertical = false}},
 	is_ground_content = true,
-	groups = {crumbly=3,soil=1, lottmapgen_grass=1, not_in_creative_inventory =1},
+	groups = {crumbly=3,soil=1, grass=1, not_in_creative_inventory=1, spreading_dirt_type=1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name="default_grass_footstep", gain=0.25},
@@ -283,23 +283,7 @@ minetest.register_node("lottmapgen:ithilien_grass", {
 minetest.register_node("lottmapgen:default_grass", {
 	tiles = {"default_grass.png", "default_dirt.png", {name = "default_dirt.png^default_grass_side.png", tileable_vertical = false}},
 	is_ground_content = true,
-	groups = {crumbly=3, soil=1,lottmapgen_grass=1,not_in_creative_inventory=1},
+	groups = {crumbly=3, soil=1,grass=1,not_in_creative_inventory=1,spreading_dirt_type=1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults()
-})
-
-minetest.register_abm({
-	nodenames = {"group:lottmapgen_grass"},
-	interval = 2,
-	chance = 20,
-	action = function(pos, node)
-		local above = {x=pos.x, y=pos.y+1, z=pos.z}
-		local name = minetest.get_node(above).name
-		local nodedef = minetest.registered_nodes[name]
-		if name ~= "ignore" and nodedef
-				and not ((nodedef.sunlight_propagates or nodedef.paramtype == "light")
-				and nodedef.liquidtype == "none") then
-			minetest.set_node(pos, {name = "default:dirt"})
-		end
-	end
 })

--- a/mods/_minetest_game/default/functions.lua
+++ b/mods/_minetest_game/default/functions.lua
@@ -1,82 +1,60 @@
--- mods/default/functions.lua
-
--- проверка на возможность роста деревьев
-function default.can_grow(pos)
-	local n
-	for p = pos.y + 1, pos.y + 20 do
-		n = minetest.get_node({ x = pos.x, y = p, z = pos.z })
-		if (n.name ~= "air") then
-			return false
-		end
-	end
-	local node_under = minetest.get_node_or_nil({ x = pos.x, y = pos.y - 1, z = pos.z })
-	if not node_under then
-		return false
-	end
-	local name_under = node_under.name
-	local is_soil    = minetest.get_item_group(name_under, "soil")
-	if is_soil == 0 then
-		return false
-	end
-	local light_level = minetest.get_node_light(pos)
-	if not light_level or light_level < 13 then
-		return false
-	end
-
-	return true
-end
-
 --
 -- Sounds
 --
 
 function default.node_sound_defaults(table)
-	table          = table or {}
-	table.footstep = table.footstep or { name = "", gain = 1.0 }
-	table.dug      = table.dug or { name = "default_dug_node", gain = 0.25 }
-	table.place    = table.place or { name = "default_place_node_hard", gain = 1.0 }
-
+	table = table or {}
+	table.footstep = table.footstep or
+			{name = "", gain = 1.0}
+	table.dug = table.dug or
+			{name = "default_dug_node", gain = 0.25}
+	table.place = table.place or
+			{name = "default_place_node_hard", gain = 1.0}
 	return table
 end
 
 function default.node_sound_stone_defaults(table)
-	table          = table or {}
-	table.footstep = table.footstep or { name = "default_hard_footstep", gain = 0.5 }
-	table.dug      = table.dug or { name = "default_hard_footstep", gain = 1.0 }
-
+	table = table or {}
+	table.footstep = table.footstep or
+			{name = "default_hard_footstep", gain = 0.3}
+	table.dug = table.dug or
+			{name = "default_hard_footstep", gain = 1.0}
 	default.node_sound_defaults(table)
-
 	return table
 end
 
 function default.node_sound_dirt_defaults(table)
-	table          = table or {}
-	table.footstep = table.footstep or { name = "default_dirt_footstep", gain = 1.0 }
-	table.dug      = table.dug or { name = "default_dirt_footstep", gain = 1.5 }
-	table.place    = table.place or { name = "default_place_node", gain = 1.0 }
-
+	table = table or {}
+	table.footstep = table.footstep or
+			{name = "default_dirt_footstep", gain = 0.4}
+	table.dug = table.dug or
+			{name = "default_dirt_footstep", gain = 1.0}
+	table.place = table.place or
+			{name = "default_place_node", gain = 1.0}
 	default.node_sound_defaults(table)
-
 	return table
 end
 
 function default.node_sound_sand_defaults(table)
-	table          = table or {}
-	table.footstep = table.footstep or { name = "default_sand_footstep", gain = 0.5 }
-	table.dug      = table.dug or { name = "default_sand_footstep", gain = 1.0 }
-	table.place    = table.place or { name = "default_place_node", gain = 1.0 }
-
+	table = table or {}
+	table.footstep = table.footstep or
+			{name = "default_sand_footstep", gain = 0.05}
+	table.dug = table.dug or
+			{name = "default_sand_footstep", gain = 0.15}
+	table.place = table.place or
+			{name = "default_place_node", gain = 1.0}
 	default.node_sound_defaults(table)
-
 	return table
 end
 
 function default.node_sound_gravel_defaults(table)
 	table = table or {}
 	table.footstep = table.footstep or
-			{name = "default_gravel_footstep", gain = 0.4}
+			{name = "default_gravel_footstep", gain = 0.1}
+	table.dig = table.dig or
+			{name = "default_gravel_dig", gain = 0.35}
 	table.dug = table.dug or
-			{name = "default_gravel_footstep", gain = 1.0}
+			{name = "default_gravel_dug", gain = 1.0}
 	table.place = table.place or
 			{name = "default_place_node", gain = 1.0}
 	default.node_sound_defaults(table)
@@ -84,34 +62,48 @@ function default.node_sound_gravel_defaults(table)
 end
 
 function default.node_sound_wood_defaults(table)
-	table          = table or {}
-	table.footstep = table.footstep or { name = "default_wood_footstep", gain = 0.5 }
-	table.dug      = table.dug or { name = "default_wood_footstep", gain = 1.0 }
-
+	table = table or {}
+	table.footstep = table.footstep or
+			{name = "default_wood_footstep", gain = 0.3}
+	table.dug = table.dug or
+			{name = "default_wood_footstep", gain = 1.0}
 	default.node_sound_defaults(table)
-
 	return table
 end
 
 function default.node_sound_leaves_defaults(table)
-	table          = table or {}
-	table.footstep = table.footstep or { name = "default_grass_footstep", gain = 0.35 }
-	table.dug      = table.dug or { name = "default_grass_footstep", gain = 0.85 }
-	table.dig      = table.dig or { name = "default_dig_crumbly", gain = 0.4 }
-	table.place    = table.place or { name = "default_place_node", gain = 1.0 }
-
+	table = table or {}
+	table.footstep = table.footstep or
+			{name = "default_grass_footstep", gain = 0.45}
+	table.dug = table.dug or
+			{name = "default_grass_footstep", gain = 0.7}
+	table.place = table.place or
+			{name = "default_place_node", gain = 1.0}
 	default.node_sound_defaults(table)
-
 	return table
 end
 
 function default.node_sound_glass_defaults(table)
-	table          = table or {}
-	table.footstep = table.footstep or { name = "default_glass_footstep", gain = 0.5 }
-	table.dug      = table.dug or { name = "default_break_glass", gain = 1.0 }
-
+	table = table or {}
+	table.footstep = table.footstep or
+			{name = "default_glass_footstep", gain = 0.3}
+	table.dig = table.dig or
+			{name = "default_glass_footstep", gain = 0.5}
+	table.dug = table.dug or
+			{name = "default_break_glass", gain = 1.0}
 	default.node_sound_defaults(table)
+	return table
+end
 
+function default.node_sound_ice_defaults(table)
+	table = table or {}
+	table.footstep = table.footstep or
+			{name = "default_ice_footstep", gain = 0.3}
+	table.dig = table.dig or
+			{name = "default_ice_dig", gain = 0.5}
+	table.dug = table.dug or
+			{name = "default_ice_dug", gain = 0.5}
+	default.node_sound_defaults(table)
 	return table
 end
 
@@ -153,145 +145,153 @@ end
 
 
 --
--- Legacy
---
-
-function default.spawn_falling_node(p, nodename)
-	spawn_falling_node(p, nodename)
-end
-
--- Horrible crap to support old code
--- Don't use this and never do what this does, it's completely wrong!
--- (More specifically, the client and the C++ code doesn't get the group)
-function default.register_falling_node(nodename, texture)
-	minetest.log("error", debug.traceback())
-	minetest.log('error', "WARNING: default.register_falling_node is deprecated")
-	if minetest.registered_nodes[nodename] then
-		minetest.registered_nodes[nodename].groups.falling_node = 1
-	end
-end
-
---
--- Global callbacks
---
-
--- Global environment step function
-function on_step(dtime)
-	-- print("on_step")
-end
-minetest.register_globalstep(on_step)
-
-function on_placenode(p, node)
-	--print("on_placenode")
-end
-minetest.register_on_placenode(on_placenode)
-
-function on_dignode(p, node)
-	--print("on_dignode")
-end
-minetest.register_on_dignode(on_dignode)
-
-function on_punchnode(p, node)
-end
-minetest.register_on_punchnode(on_punchnode)
-
-
---
 -- Lavacooling
 --
 
-default.cool_lava_source  = function(pos)
-	minetest.set_node(pos, { name = "default:obsidian" })
-	minetest.sound_play("default_cool_lava", { pos = pos, gain = 0.25 })
+default.cool_lava = function(pos, node)
+	if node.name == "default:lava_source" then
+		minetest.set_node(pos, {name = "default:obsidian"})
+	else -- Lava flowing
+		minetest.set_node(pos, {name = "default:stone"})
+	end
+	minetest.sound_play("default_cool_lava",
+		{pos = pos, max_hear_distance = 16, gain = 0.25}, true)
 end
 
-default.cool_lava_flowing = function(pos)
-	minetest.set_node(pos, { name = "default:stone" })
-	minetest.sound_play("default_cool_lava", { pos = pos, gain = 0.25 })
+if minetest.settings:get_bool("enable_lavacooling") ~= false then
+	minetest.register_abm({
+		label = "Lava cooling",
+		nodenames = {"default:lava_source", "default:lava_flowing"},
+		neighbors = {"group:cools_lava", "group:water"},
+		interval = 2,
+		chance = 2,
+		catch_up = false,
+		action = function(...)
+			default.cool_lava(...)
+		end,
+	})
 end
 
-minetest.register_abm({
-	nodenames = { "default:lava_flowing" },
-	neighbors = { "group:water" },
-	interval  = 1,
-	chance    = 1,
-	action    = function(pos, node, active_object_count, active_object_count_wider)
-		default.cool_lava_flowing(pos, node, active_object_count, active_object_count_wider)
-	end,
-})
 
-minetest.register_abm({
-	nodenames = { "default:lava_source" },
-	neighbors = { "group:water" },
-	interval  = 1,
-	chance    = 1,
-	action    = function(pos, node, active_object_count, active_object_count_wider)
-		default.cool_lava_source(pos, node, active_object_count, active_object_count_wider)
-	end,
-})
+--
+-- Optimized helper to put all items in an inventory into a drops list
+--
+
+function default.get_inventory_drops(pos, inventory, drops)
+	local inv = minetest.get_meta(pos):get_inventory()
+	local n = #drops
+	for i = 1, inv:get_size(inventory) do
+		local stack = inv:get_stack(inventory, i)
+		if stack:get_count() > 0 then
+			drops[n+1] = stack:to_table()
+			n = n + 1
+		end
+	end
+end
+
 
 --
 -- Papyrus and cactus growing
 --
 
+-- Wrapping the functions in ABM action is necessary to make overriding them possible
+
+function default.grow_cactus(pos, node)
+	if node.param2 >= 4 then
+		return
+	end
+	pos.y = pos.y - 1
+	if minetest.get_item_group(minetest.get_node(pos).name, "sand") == 0 then
+		return
+	end
+	pos.y = pos.y + 1
+	local height = 0
+	while node.name == "default:cactus" and height < 4 do
+		height = height + 1
+		pos.y = pos.y + 1
+		node = minetest.get_node(pos)
+	end
+	if height == 4 or node.name ~= "air" then
+		return
+	end
+	if minetest.get_node_light(pos) < 13 then
+		return
+	end
+	minetest.set_node(pos, {name = "default:cactus"})
+	return true
+end
+
+function default.grow_papyrus(pos, node)
+	pos.y = pos.y - 1
+	local name = minetest.get_node(pos).name
+	if name ~= "default:dirt" and
+			name ~= "default:dirt_with_grass" and
+			name ~= "default:dirt_with_dry_grass" and
+			name ~= "default:dirt_with_rainforest_litter" and
+			name ~= "default:dry_dirt" and
+			name ~= "default:dry_dirt_with_dry_grass" then
+		return
+	end
+	if not minetest.find_node_near(pos, 3, {"group:water"}) then
+		return
+	end
+	pos.y = pos.y + 1
+	local height = 0
+	while node.name == "default:papyrus" and height < 4 do
+		height = height + 1
+		pos.y = pos.y + 1
+		node = minetest.get_node(pos)
+	end
+	if height == 4 or node.name ~= "air" then
+		return
+	end
+	if minetest.get_node_light(pos) < 13 then
+		return
+	end
+	minetest.set_node(pos, {name = "default:papyrus"})
+	return true
+end
+
 minetest.register_abm({
-	nodenames = { "default:cactus" },
-	neighbors = { "group:sand" },
-	interval  = 50,
-	chance    = 20,
-	action    = function(pos, node)
-		pos.y      = pos.y - 1
-		local name = minetest.get_node(pos).name
-		if minetest.get_item_group(name, "sand") ~= 0 then
-			pos.y        = pos.y + 1
-			local height = 0
-			while minetest.get_node(pos).name == "default:cactus" and height < 4 do
-				height = height + 1
-				pos.y  = pos.y + 1
-			end
-			if height < 4 then
-				if minetest.get_node(pos).name == "air" then
-					minetest.set_node(pos, { name = "default:cactus" })
-				end
-			end
-		end
-	end,
+	label = "Grow cactus",
+	nodenames = {"default:cactus"},
+	neighbors = {"group:sand"},
+	interval = 12,
+	chance = 83,
+	action = function(...)
+		default.grow_cactus(...)
+	end
 })
 
 minetest.register_abm({
-	nodenames = { "default:papyrus" },
-	neighbors = { "group:soil", "default:sand" },
-	interval  = 50,
-	chance    = 20,
-	action    = function(pos, node)
-		pos.y      = pos.y - 1
-		local name = minetest.get_node(pos).name
-		if (minetest.registered_nodes[name].groups["soil"]) or (name == "default:sand") then
-			if minetest.find_node_near(pos, 3, { "group:water" }) == nil then
-				return
-			end
-			pos.y        = pos.y + 1
-			local height = 0
-			while minetest.get_node(pos).name == "default:papyrus" and height < 4 do
-				height = height + 1
-				pos.y  = pos.y + 1
-			end
-			if height < 4 then
-				if minetest.get_node(pos).name == "air" then
-					minetest.set_node(pos, { name = "default:papyrus" })
-				end
-			end
-		end
-	end,
+	label = "Grow papyrus",
+	nodenames = {"default:papyrus"},
+	-- Grows on the dirt and surface dirt nodes of the biomes papyrus appears in,
+	-- including the old savanna nodes.
+	-- 'default:dirt_with_grass' is here only because it was allowed before.
+	neighbors = {
+		"default:dirt",
+		"default:dirt_with_grass",
+		"default:dirt_with_dry_grass",
+		"default:dirt_with_rainforest_litter",
+		"default:dry_dirt",
+		"default:dry_dirt_with_dry_grass",
+	},
+	interval = 14,
+	chance = 71,
+	action = function(...)
+		default.grow_papyrus(...)
+	end
 })
+
 
 --
--- dig upwards
+-- Dig upwards
 --
 
 function default.dig_up(pos, node, digger)
 	if digger == nil then return end
-	local np = { x = pos.x, y = pos.y + 1, z = pos.z }
+	local np = {x = pos.x, y = pos.y + 1, z = pos.z}
 	local nn = minetest.get_node(np)
 	if nn.name == node.name then
 		minetest.node_dig(np, nn, digger)
@@ -300,161 +300,382 @@ end
 
 
 --
+-- Fence registration helper
+--
+local fence_collision_extra = minetest.settings:get_bool("enable_fence_tall") and 3/8 or 0
+
+function default.register_fence(name, def)
+	minetest.register_craft({
+		output = name .. " 4",
+		recipe = {
+			{ def.material, 'group:stick', def.material },
+			{ def.material, 'group:stick', def.material },
+		}
+	})
+
+	local fence_texture = "default_fence_overlay.png^" .. def.texture ..
+			"^default_fence_overlay.png^[makealpha:255,126,126"
+	-- Allow almost everything to be overridden
+	local default_fields = {
+		paramtype = "light",
+		drawtype = "nodebox",
+		node_box = {
+			type = "connected",
+			fixed = {-1/8, -1/2, -1/8, 1/8, 1/2, 1/8},
+			-- connect_top =
+			-- connect_bottom =
+			connect_front = {{-1/16,  3/16, -1/2,   1/16,  5/16, -1/8 },
+				         {-1/16, -5/16, -1/2,   1/16, -3/16, -1/8 }},
+			connect_left =  {{-1/2,   3/16, -1/16, -1/8,   5/16,  1/16},
+				         {-1/2,  -5/16, -1/16, -1/8,  -3/16,  1/16}},
+			connect_back =  {{-1/16,  3/16,  1/8,   1/16,  5/16,  1/2 },
+				         {-1/16, -5/16,  1/8,   1/16, -3/16,  1/2 }},
+			connect_right = {{ 1/8,   3/16, -1/16,  1/2,   5/16,  1/16},
+				         { 1/8,  -5/16, -1/16,  1/2,  -3/16,  1/16}}
+		},
+		collision_box = {
+			type = "connected",
+			fixed = {-1/8, -1/2, -1/8, 1/8, 1/2 + fence_collision_extra, 1/8},
+			-- connect_top =
+			-- connect_bottom =
+			connect_front = {-1/8, -1/2, -1/2,  1/8, 1/2 + fence_collision_extra, -1/8},
+			connect_left =  {-1/2, -1/2, -1/8, -1/8, 1/2 + fence_collision_extra,  1/8},
+			connect_back =  {-1/8, -1/2,  1/8,  1/8, 1/2 + fence_collision_extra,  1/2},
+			connect_right = { 1/8, -1/2, -1/8,  1/2, 1/2 + fence_collision_extra,  1/8}
+		},
+		connects_to = {"group:fence", "group:wood", "group:tree", "group:wall"},
+		inventory_image = fence_texture,
+		wield_image = fence_texture,
+		tiles = {def.texture},
+		sunlight_propagates = true,
+		is_ground_content = false,
+		groups = {},
+	}
+	for k, v in pairs(default_fields) do
+		if def[k] == nil then
+			def[k] = v
+		end
+	end
+
+	-- Always add to the fence group, even if no group provided
+	def.groups.fence = 1
+
+	def.texture = nil
+	def.material = nil
+
+	minetest.register_node(name, def)
+end
+
+
+--
+-- Fence rail registration helper
+--
+
+function default.register_fence_rail(name, def)
+	minetest.register_craft({
+		output = name .. " 16",
+		recipe = {
+			{ def.material, def.material },
+			{ "", ""},
+			{ def.material, def.material },
+		}
+	})
+
+	local fence_rail_texture = "default_fence_rail_overlay.png^" .. def.texture ..
+			"^default_fence_rail_overlay.png^[makealpha:255,126,126"
+	-- Allow almost everything to be overridden
+	local default_fields = {
+		paramtype = "light",
+		drawtype = "nodebox",
+		node_box = {
+			type = "connected",
+			fixed = {{-1/16,  3/16, -1/16, 1/16,  5/16, 1/16},
+				 {-1/16, -3/16, -1/16, 1/16, -5/16, 1/16}},
+			-- connect_top =
+			-- connect_bottom =
+			connect_front = {{-1/16,  3/16, -1/2,   1/16,  5/16, -1/16},
+				         {-1/16, -5/16, -1/2,   1/16, -3/16, -1/16}},
+			connect_left =  {{-1/2,   3/16, -1/16, -1/16,  5/16,  1/16},
+				         {-1/2,  -5/16, -1/16, -1/16, -3/16,  1/16}},
+			connect_back =  {{-1/16,  3/16,  1/16,  1/16,  5/16,  1/2 },
+				         {-1/16, -5/16,  1/16,  1/16, -3/16,  1/2 }},
+			connect_right = {{ 1/16,  3/16, -1/16,  1/2,   5/16,  1/16},
+		                         { 1/16, -5/16, -1/16,  1/2,  -3/16,  1/16}}
+		},
+		collision_box = {
+			type = "connected",
+			fixed = {-1/8, -1/2, -1/8, 1/8, 1/2 + fence_collision_extra, 1/8},
+			-- connect_top =
+			-- connect_bottom =
+			connect_front = {-1/8, -1/2, -1/2,  1/8, 1/2 + fence_collision_extra, -1/8},
+			connect_left =  {-1/2, -1/2, -1/8, -1/8, 1/2 + fence_collision_extra,  1/8},
+			connect_back =  {-1/8, -1/2,  1/8,  1/8, 1/2 + fence_collision_extra,  1/2},
+			connect_right = { 1/8, -1/2, -1/8,  1/2, 1/2 + fence_collision_extra,  1/8}
+		},
+		connects_to = {"group:fence", "group:wall"},
+		inventory_image = fence_rail_texture,
+		wield_image = fence_rail_texture,
+		tiles = {def.texture},
+		sunlight_propagates = true,
+		is_ground_content = false,
+		groups = {},
+	}
+	for k, v in pairs(default_fields) do
+		if def[k] == nil then
+			def[k] = v
+		end
+	end
+
+	-- Always add to the fence group, even if no group provided
+	def.groups.fence = 1
+
+	def.texture = nil
+	def.material = nil
+
+	minetest.register_node(name, def)
+end
+
+--
+-- Mese post registration helper
+--
+
+function default.register_mesepost(name, def)
+	minetest.register_craft({
+		output = name .. " 4",
+		recipe = {
+			{'', 'default:glass', ''},
+			{'default:mese_crystal', 'default:mese_crystal', 'default:mese_crystal'},
+			{'', def.material, ''},
+		}
+	})
+
+	local post_texture = def.texture .. "^default_mese_post_light_side.png^[makealpha:0,0,0"
+	local post_texture_dark = def.texture .. "^default_mese_post_light_side_dark.png^[makealpha:0,0,0"
+	-- Allow almost everything to be overridden
+	local default_fields = {
+		wield_image = post_texture,
+		drawtype = "nodebox",
+		node_box = {
+			type = "fixed",
+			fixed = {
+				{-2 / 16, -8 / 16, -2 / 16, 2 / 16, 8 / 16, 2 / 16},
+			},
+		},
+		paramtype = "light",
+		tiles = {def.texture, def.texture, post_texture_dark, post_texture_dark, post_texture, post_texture},
+		use_texture_alpha = "opaque",
+		light_source = default.LIGHT_MAX,
+		sunlight_propagates = true,
+		is_ground_content = false,
+		groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
+		sounds = default.node_sound_wood_defaults(),
+	}
+	for k, v in pairs(default_fields) do
+		if def[k] == nil then
+			def[k] = v
+		end
+	end
+
+	def.texture = nil
+	def.material = nil
+
+	minetest.register_node(name, def)
+end
+
+--
 -- Leafdecay
 --
 
--- To enable leaf decay for a node, add it to the "leafdecay" group.
---
--- The rating of the group determines how far from a node in the group "tree"
--- the node can be without decaying.
---
--- If param2 of the node is ~= 0, the node will always be preserved. Thus, if
--- the player places a node of that kind, you will want to set param2=1 or so.
---
--- If the node is in the leafdecay_drop group then the it will always be dropped
--- as an item
+-- Prevent decay of placed leaves
 
-default.leafdecay_trunk_cache = {}
-default.leafdecay_enable_cache = true
--- Spread the load of finding trunks
-default.leafdecay_trunk_find_allow_accumulator = 0
+default.after_place_leaves = function(pos, placer, itemstack, pointed_thing)
+	if placer and placer:is_player() then
+		local node = minetest.get_node(pos)
+		node.param2 = 1
+		minetest.set_node(pos, node)
+	end
+end
 
-minetest.register_globalstep(function(dtime)
-	local finds_per_second                         = 5000
-	default.leafdecay_trunk_find_allow_accumulator = math.floor(dtime * finds_per_second)
-end)
+-- Leafdecay
+local function leafdecay_after_destruct(pos, oldnode, def)
+	for _, v in pairs(minetest.find_nodes_in_area(vector.subtract(pos, def.radius),
+			vector.add(pos, def.radius), def.leaves)) do
+		local node = minetest.get_node(v)
+		local timer = minetest.get_node_timer(v)
+		if node.param2 ~= 1 and not timer:is_started() then
+			timer:start(math.random(20, 120) / 10)
+		end
+	end
+end
+
+local movement_gravity = tonumber(
+	minetest.settings:get("movement_gravity")) or 9.81
+
+local function leafdecay_on_timer(pos, def)
+	if minetest.find_node_near(pos, def.radius, def.trunks) then
+		return false
+	end
+
+	local node = minetest.get_node(pos)
+	local drops = minetest.get_node_drops(node.name)
+	for _, item in ipairs(drops) do
+		local is_leaf
+		for _, v in pairs(def.leaves) do
+			if v == item then
+				is_leaf = true
+			end
+		end
+		if minetest.get_item_group(item, "leafdecay_drop") ~= 0 or
+				not is_leaf then
+			minetest.add_item({
+				x = pos.x - 0.5 + math.random(),
+				y = pos.y - 0.5 + math.random(),
+				z = pos.z - 0.5 + math.random(),
+			}, item)
+		end
+	end
+
+	minetest.remove_node(pos)
+	minetest.check_for_falling(pos)
+
+	-- spawn a few particles for the removed node
+	minetest.add_particlespawner({
+		amount = 8,
+		time = 0.001,
+		minpos = vector.subtract(pos, {x=0.5, y=0.5, z=0.5}),
+		maxpos = vector.add(pos, {x=0.5, y=0.5, z=0.5}),
+		minvel = vector.new(-0.5, -1, -0.5),
+		maxvel = vector.new(0.5, 0, 0.5),
+		minacc = vector.new(0, -movement_gravity, 0),
+		maxacc = vector.new(0, -movement_gravity, 0),
+		minsize = 0,
+		maxsize = 0,
+		node = node,
+	})
+end
+
+function default.register_leafdecay(def)
+	assert(def.leaves)
+	assert(def.trunks)
+	assert(def.radius)
+	for _, v in pairs(def.trunks) do
+		minetest.override_item(v, {
+			after_destruct = function(pos, oldnode)
+				leafdecay_after_destruct(pos, oldnode, def)
+			end,
+		})
+	end
+	for _, v in pairs(def.leaves) do
+		minetest.override_item(v, {
+			on_timer = function(pos)
+				leafdecay_on_timer(pos, def)
+			end,
+		})
+	end
+end
+
+
+--
+-- Convert default:dirt to something that fits the environment
+--
 
 minetest.register_abm({
-	nodenames = { "group:leafdecay" },
-	neighbors = { "air", "group:liquid" },
-	-- A low interval and a high inverse chance spreads the load
-	interval  = 2,
-	chance    = 5,
+	label = "Grass spread",
+	nodenames = {"default:dirt"},
+	neighbors = {
+		"air",
+		"group:grass",
+		"group:dry_grass",
+		"default:snow",
+	},
+	interval = 6,
+	chance = 50,
+	catch_up = false,
+	action = function(pos, node)
+		-- Check for darkness: night, shadow or under a light-blocking node
+		-- Returns if ignore above
+		local above = {x = pos.x, y = pos.y + 1, z = pos.z}
+		if (minetest.get_node_light(above) or 0) < 13 then
+			return
+		end
 
-	action    = function(p0, node, _, _)
-		--print("leafdecay ABM at "..p0.x..", "..p0.y..", "..p0.z..")")
-		local do_preserve = false
-		local d           = minetest.registered_nodes[node.name].groups.leafdecay
-		if not d or d == 0 then
-			--print("not groups.leafdecay")
+		-- Look for spreading dirt-type neighbours
+		local p2 = minetest.find_node_near(pos, 1, "group:spreading_dirt_type")
+		if p2 then
+			local n3 = minetest.get_node(p2)
+			minetest.set_node(pos, {name = n3.name})
 			return
 		end
-		local n0 = minetest.get_node(p0)
-		if n0.param2 ~= 0 then
-			--print("param2 ~= 0")
-			return
-		end
-		local p0_hash = nil
-		if default.leafdecay_enable_cache then
-			p0_hash      = minetest.hash_node_position(p0)
-			local trunkp = default.leafdecay_trunk_cache[p0_hash]
-			if trunkp then
-				local n   = minetest.get_node(trunkp)
-				local reg = minetest.registered_nodes[n.name]
-				-- Assume ignore is a trunk, to make the thing work at the border of the active area
-				if n.name == "ignore" or (reg and reg.groups.tree and reg.groups.tree ~= 0) then
-					--print("cached trunk still exists")
-					return
-				end
-				-- Cache is invalid
-				table.remove(default.leafdecay_trunk_cache, p0_hash)
-			end
-		end
-		if default.leafdecay_trunk_find_allow_accumulator <= 0 then
-			return
-		end
-		default.leafdecay_trunk_find_allow_accumulator = default.leafdecay_trunk_find_allow_accumulator - 1
-		-- Assume ignore is a trunk, to make the thing work at the border of the active area
-		local p1                                       = minetest.find_node_near(p0, d, { "ignore", "group:tree" })
-		if p1 then
-			do_preserve = true
-			if default.leafdecay_enable_cache then
-				-- Cache the trunk
-				default.leafdecay_trunk_cache[p0_hash] = p1
-			end
-		end
-		if not do_preserve then
-			-- Drop stuff other than the node itself
-			local itemstacks = minetest.get_node_drops(n0.name)
-			for _, itemname in ipairs(itemstacks) do
-				if minetest.get_item_group(n0.name, "leafdecay_drop") ~= 0 or
-					itemname ~= n0.name then
-					local p_drop = {
-						x = p0.x - 0.5 + math.random(),
-						y = p0.y - 0.5 + math.random(),
-						z = p0.z - 0.5 + math.random(),
-					}
-					minetest.add_item(p_drop, itemname)
-				end
-			end
-			-- Remove node
-			minetest.remove_node(p0)
-			minetest.check_for_falling(p0)
+
+		-- Else, any seeding nodes on top?
+		local name = minetest.get_node(above).name
+		-- Snow check is cheapest, so comes first
+		if name == "default:snow" then
+			minetest.set_node(pos, {name = "default:dirt_with_snow"})
+		elseif minetest.get_item_group(name, "grass") ~= 0 then
+			minetest.set_node(pos, {name = "default:dirt_with_grass"})
+		elseif minetest.get_item_group(name, "dry_grass") ~= 0 then
+			minetest.set_node(pos, {name = "default:dirt_with_dry_grass"})
 		end
 	end
 })
 
---This allows trees act *almost* like falling nodes, useful for big trees!
 
-local falling_trees = minetest.settings:get_bool("falling_trees")
+--
+-- Grass and dry grass removed in darkness
+--
 
-if not falling_trees then
-	if minetest.is_singleplayer() then
-		falling_trees = false
-	else
-		falling_trees = true
-	end
-end
-
-if falling_trees == true then
-	function default.dig_tree(pos, node, name, digger, height, radius, drop)
-		minetest.node_dig(pos, node, digger)
-
-		if minetest.is_protected(pos, digger:get_player_name()) then
-			return
-		end
-
-		local base_y = pos.y
-		for i = 1, (height + 5) do
-			pos.y        = base_y + i
-			local node_i = minetest.get_node(pos)
-			if node_i.name ~= name or i == (height + 5) then
-				minetest.remove_node({ x = pos.x, y = pos.y - 1, z = pos.z })
-				for k = -radius, radius do
-					for l = -radius, radius do
-						for j = 0, 1 do
-							local tree_bellow = minetest.get_node({ x = pos.x + k, y = pos.y - 1, z = pos.z + l })
-							if tree_bellow.name ~= name then
-								local pos1 = { x = pos.x + k, y = pos.y + j, z = pos.z + l }
-								if minetest.get_node(pos1).name == name then
-									minetest.spawn_item(pos1, drop)
-									minetest.remove_node(pos1)
-								end
-							end
-						end
-					end
-				end
-				return
-			elseif node_i.name == name then
-				minetest.set_node({ x = pos.x, y = pos.y - 1, z = pos.z }, { name = name })
+minetest.register_abm({
+	label = "Grass covered",
+	nodenames = {"group:spreading_dirt_type", "default:dry_dirt_with_dry_grass"},
+	interval = 8,
+	chance = 50,
+	catch_up = false,
+	action = function(pos, node)
+		local above = {x = pos.x, y = pos.y + 1, z = pos.z}
+		local name = minetest.get_node(above).name
+		local nodedef = minetest.registered_nodes[name]
+		if name ~= "ignore" and nodedef and not ((nodedef.sunlight_propagates or
+				nodedef.paramtype == "light") and
+				nodedef.liquidtype == "none") then
+			if node.name == "default:dry_dirt_with_dry_grass" then
+				minetest.set_node(pos, {name = "default:dry_dirt"})
+			else
+				minetest.set_node(pos, {name = "default:dirt"})
 			end
 		end
 	end
-else
-	function default.dig_tree(pos, node, name, digger, height, radius, drop)
-		minetest.node_dig(pos, node, digger)
-		return
-	end
-end
+})
 
-minetest.register_on_punchplayer(function(player, hitter, time_from_last_punch, tool_capabilities)
-	local weapon = hitter:get_wielded_item()
-	if tool_capabilities ~= nil then
-		local wear = ((tool_capabilities.full_punch_interval or 1.4) / 75) * 9000
-		weapon:add_wear(wear)
-		hitter:set_wielded_item(weapon)
+
+--
+-- Moss growth on cobble near water
+--
+
+local moss_correspondences = {
+	["default:cobble"] = "default:mossycobble",
+	["stairs:slab_cobble"] = "stairs:slab_mossycobble",
+	["stairs:stair_cobble"] = "stairs:stair_mossycobble",
+	["stairs:stair_inner_cobble"] = "stairs:stair_inner_mossycobble",
+	["stairs:stair_outer_cobble"] = "stairs:stair_outer_mossycobble",
+	["walls:cobble"] = "walls:mossycobble",
+}
+minetest.register_abm({
+	label = "Moss growth",
+	nodenames = {"default:cobble", "stairs:slab_cobble", "stairs:stair_cobble",
+		"stairs:stair_inner_cobble", "stairs:stair_outer_cobble",
+		"walls:cobble"},
+	neighbors = {"group:water"},
+	interval = 16,
+	chance = 200,
+	catch_up = false,
+	action = function(pos, node)
+		node.name = moss_correspondences[node.name]
+		if node.name then
+			minetest.set_node(pos, node)
+		end
 	end
-end)
+})
 
 --
 -- Register a craft to copy the metadata of items

--- a/mods/_minetest_game/default/init.lua
+++ b/mods/_minetest_game/default/init.lua
@@ -6,9 +6,6 @@
 -- Load support for MT game translation.
 local S = minetest.get_translator("default")
 
-WATER_ALPHA = 160
-WATER_VISC = 1
-LAVA_VISC = 7
 LIGHT_MAX = 14
 
 -- Definitions made by this mod that other mods can use too

--- a/mods/_minetest_game/default/nodes.lua
+++ b/mods/_minetest_game/default/nodes.lua
@@ -1,87 +1,286 @@
-local S = default.get_translator
 -- mods/default/nodes.lua
 
+-- support for MT game translation.
+local S = default.get_translator
 
--- Stone / Камень
+--[[ Node name convention:
+
+Although many node names are in combined-word form, the required form for new
+node names is words separated by underscores. If both forms are used in written
+language (for example pinewood and pine wood) the underscore form should be used.
+
+--]]
+
+
+--[[ Index:
+
+Stone
+-----
+(1. Material 2. Cobble variant 3. Brick variant 4. Modified forms)
+
+default:stone
+default:cobble
+default:stonebrick
+default:stone_block
+default:mossycobble
+
+default:desert_stone
+default:desert_cobble
+default:desert_stonebrick
+default:desert_stone_block
+
+default:sandstone
+default:sandstonebrick
+default:sandstone_block
+default:desert_sandstone
+default:desert_sandstone_brick
+default:desert_sandstone_block
+default:silver_sandstone
+default:silver_sandstone_brick
+default:silver_sandstone_block
+
+default:obsidian
+default:obsidianbrick
+default:obsidian_block
+
+Soft / Non-Stone
+----------------
+(1. Material 2. Modified forms)
+
+default:dirt
+default:dirt_with_grass
+default:dirt_with_grass_footsteps
+default:dirt_with_dry_grass
+default:dirt_with_snow
+default:dirt_with_rainforest_litter
+default:dirt_with_coniferous_litter
+default:dry_dirt
+default:dry_dirt_with_dry_grass
+
+default:permafrost
+default:permafrost_with_stones
+default:permafrost_with_moss
+
+default:sand
+default:desert_sand
+default:silver_sand
+
+default:gravel
+
+default:clay
+
+default:snow
+default:snowblock
+default:ice
+default:cave_ice
+
+Trees
+-----
+(1. Trunk 2. Fabricated trunk 3. Leaves 4. Sapling 5. Fruits)
+
+default:tree
+default:wood
+default:leaves
+default:sapling
+default:apple
+
+default:jungletree
+default:junglewood
+default:jungleleaves
+default:junglesapling
+default:emergent_jungle_sapling
+
+default:pine_tree
+default:pine_wood
+default:pine_needles
+default:pine_sapling
+
+default:acacia_tree
+default:acacia_wood
+default:acacia_leaves
+default:acacia_sapling
+
+default:aspen_tree
+default:aspen_wood
+default:aspen_leaves
+default:aspen_sapling
+
+Ores
+----
+(1. In stone 2. Blocks)
+
+default:stone_with_coal
+default:coalblock
+
+default:stone_with_iron
+default:steelblock
+
+default:stone_with_copper
+default:copperblock
+
+default:stone_with_tin
+default:tinblock
+
+default:bronzeblock
+
+default:stone_with_gold
+default:goldblock
+
+default:stone_with_mese
+default:mese
+
+default:stone_with_diamond
+default:diamondblock
+
+Plantlife
+---------
+
+default:cactus
+default:large_cactus_seedling
+
+default:papyrus
+default:dry_shrub
+default:junglegrass
+
+default:grass_1
+default:grass_2
+default:grass_3
+default:grass_4
+default:grass_5
+
+default:dry_grass_1
+default:dry_grass_2
+default:dry_grass_3
+default:dry_grass_4
+default:dry_grass_5
+
+default:fern_1
+default:fern_2
+default:fern_3
+
+default:marram_grass_1
+default:marram_grass_2
+default:marram_grass_3
+
+default:bush_stem
+default:bush_leaves
+default:bush_sapling
+default:acacia_bush_stem
+default:acacia_bush_leaves
+default:acacia_bush_sapling
+default:pine_bush_stem
+default:pine_bush_needles
+default:pine_bush_sapling
+default:blueberry_bush_leaves_with_berries
+default:blueberry_bush_leaves
+default:blueberry_bush_sapling
+
+default:sand_with_kelp
+
+Corals
+------
+
+default:coral_green
+default:coral_pink
+default:coral_cyan
+default:coral_brown
+default:coral_orange
+default:coral_skeleton
+
+Liquids
+-------
+(1. Source 2. Flowing)
+
+default:water_source
+default:water_flowing
+
+default:river_water_source
+default:river_water_flowing
+
+default:lava_source
+default:lava_flowing
+
+Tools / "Advanced" crafting / Non-"natural"
+-------------------------------------------
+
+default:bookshelf
+
+default:sign_wall_wood
+default:sign_wall_steel
+
+default:ladder_wood
+default:ladder_steel
+
+default:fence_wood
+default:fence_acacia_wood
+default:fence_junglewood
+default:fence_pine_wood
+default:fence_aspen_wood
+
+default:fence_rail_wood
+default:fence_rail_acacia_wood
+default:fence_rail_junglewood
+default:fence_rail_pine_wood
+default:fence_rail_aspen_wood
+
+default:glass
+default:obsidian_glass
+
+default:brick
+
+default:meselamp
+default:mese_post_light
+default:mese_post_light_acacia_wood
+default:mese_post_light_junglewood
+default:mese_post_light_pine_wood
+default:mese_post_light_aspen_wood
+
+Misc
+----
+
+default:cloud
+
+--]]
+
+-- Required wrapper to allow customization of default.after_place_leaves
+local function after_place_leaves(...)
+	return default.after_place_leaves(...)
+end
+
+-- Required wrapper to allow customization of default.grow_sapling
+local function grow_sapling(...)
+	return default.grow_sapling(...)
+end
+
+--
+-- Stone
+--
+
 minetest.register_node("default:stone", {
-	description       = S("Stone"),
-	tiles             = { "default_stone.png" },
-	is_ground_content = true,
-	groups            = { cracky = 3, stone = 1 },
-	drop              = 'default:cobble',
-	legacy_mineral    = true,
-	sounds            = default.node_sound_stone_defaults(),
+	description = S("Stone"),
+	tiles = {"default_stone.png"},
+	groups = {cracky = 3, stone = 1},
+	drop = "default:cobble",
+	legacy_mineral = true,
+	sounds = default.node_sound_stone_defaults(),
 })
 
-minetest.register_node("default:desert_stone", {
-	description       = S("Desert Stone"),
-	tiles             = { "default_desert_stone.png" },
-	is_ground_content = true,
-	groups            = { cracky = 3, stone = 1 },
-	drop              = 'default:desert_cobble',
-	legacy_mineral    = true,
-	sounds            = default.node_sound_stone_defaults(),
-})
-
-minetest.register_node("default:stone_with_coal", {
-	description       = S("Coal Ore"),
-	tiles             = { "default_stone.png^default_mineral_coal.png" },
-	is_ground_content = true,
-	groups            = { cracky = 3 },
-	drop              = 'default:coal_lump',
-	sounds            = default.node_sound_stone_defaults(),
-})
-
-minetest.register_node("default:stone_with_iron", {
-	description       = S("Iron Ore"),
-	tiles             = { "default_stone.png^default_mineral_iron.png" },
-	is_ground_content = true,
-	groups            = { cracky = 2 },
-	drop              = 'default:iron_lump',
-	sounds            = default.node_sound_stone_defaults(),
-})
-
-minetest.register_node("default:stone_with_copper", {
-	description       = S("Copper Ore"),
-	tiles             = { "default_stone.png^default_mineral_copper.png" },
-	is_ground_content = true,
-	groups            = { cracky = 2 },
-	drop              = 'default:copper_lump',
-	sounds            = default.node_sound_stone_defaults(),
-})
-
-minetest.register_node("default:stone_with_mese", {
-	description       = S("Mese Ore"),
-	tiles             = { "default_stone.png^default_mineral_mese.png" },
-	is_ground_content = true,
-	groups            = { cracky = 1 },
-	drop              = "default:mese_crystal",
-	sounds            = default.node_sound_stone_defaults(),
-})
-
-minetest.register_node("default:stone_with_gold", {
-	description       = S("Gold Ore"),
-	tiles             = { "default_stone.png^default_mineral_gold.png" },
-	is_ground_content = true,
-	groups            = { cracky = 2 },
-	drop              = "default:gold_lump",
-	sounds            = default.node_sound_stone_defaults(),
-})
-
-minetest.register_node("default:stone_with_diamond", {
-	description       = S("Diamond Ore"),
-	tiles             = { "default_stone.png^default_mineral_diamond.png" },
-	is_ground_content = true,
-	groups            = { cracky = 1 },
-	drop              = "default:diamond",
-	sounds            = default.node_sound_stone_defaults(),
+minetest.register_node("default:cobble", {
+	description = S("Cobblestone"),
+	tiles = {"default_cobble.png"},
+	is_ground_content = false,
+	groups = {cracky = 3, stone = 2},
+	sounds = default.node_sound_stone_defaults(),
 })
 
 minetest.register_node("default:stonebrick", {
 	description = S("Stone Brick"),
-	tiles       = { "default_stone_brick.png" },
-	groups      = { cracky = 2, stone = 1 },
-	sounds      = default.node_sound_stone_defaults(),
+	paramtype2 = "facedir",
+	place_param2 = 0,
+	tiles = {"default_stone_brick.png"},
+	is_ground_content = false,
+	groups = {cracky = 2, stone = 1},
+	sounds = default.node_sound_stone_defaults(),
 })
 
 minetest.register_node("default:stone_block", {
@@ -92,11 +291,40 @@ minetest.register_node("default:stone_block", {
 	sounds = default.node_sound_stone_defaults(),
 })
 
+minetest.register_node("default:mossycobble", {
+	description = S("Mossy Cobblestone"),
+	tiles = {"default_mossycobble.png"},
+	is_ground_content = false,
+	groups = {cracky = 3, stone = 1},
+	sounds = default.node_sound_stone_defaults(),
+})
+
+
+minetest.register_node("default:desert_stone", {
+	description = S("Desert Stone"),
+	tiles = {"default_desert_stone.png"},
+	groups = {cracky = 3, stone = 1},
+	drop = "default:desert_cobble",
+	legacy_mineral = true,
+	sounds = default.node_sound_stone_defaults(),
+})
+
+minetest.register_node("default:desert_cobble", {
+	description = S("Desert Cobblestone"),
+	tiles = {"default_desert_cobble.png"},
+	is_ground_content = false,
+	groups = {cracky = 3, stone = 2},
+	sounds = default.node_sound_stone_defaults(),
+})
+
 minetest.register_node("default:desert_stonebrick", {
-	description = S("Desert Brick"),
-	tiles       = { "default_desert_stone_brick.png" },
-	groups      = { cracky = 2, stone = 1 },
-	sounds      = default.node_sound_stone_defaults(),
+	description = S("Desert Stone Brick"),
+	paramtype2 = "facedir",
+	place_param2 = 0,
+	tiles = {"default_desert_stone_brick.png"},
+	is_ground_content = false,
+	groups = {cracky = 2, stone = 1},
+	sounds = default.node_sound_stone_defaults(),
 })
 
 minetest.register_node("default:desert_stone_block", {
@@ -106,6 +334,32 @@ minetest.register_node("default:desert_stone_block", {
 	groups = {cracky = 2, stone = 1},
 	sounds = default.node_sound_stone_defaults(),
 })
+
+minetest.register_node("default:sandstone", {
+	description = S("Sandstone"),
+	tiles = {"default_sandstone.png"},
+	groups = {crumbly = 1, cracky = 3},
+	sounds = default.node_sound_stone_defaults(),
+})
+
+minetest.register_node("default:sandstonebrick", {
+	description = S("Sandstone Brick"),
+	paramtype2 = "facedir",
+	place_param2 = 0,
+	tiles = {"default_sandstone_brick.png"},
+	is_ground_content = false,
+	groups = {cracky = 2},
+	sounds = default.node_sound_stone_defaults(),
+})
+
+minetest.register_node("default:sandstone_block", {
+	description = S("Sandstone Block"),
+	tiles = {"default_sandstone_block.png"},
+	is_ground_content = false,
+	groups = {cracky = 2},
+	sounds = default.node_sound_stone_defaults(),
+})
+
 minetest.register_node("default:desert_sandstone", {
 	description = S("Desert Sandstone"),
 	tiles = {"default_desert_sandstone.png"},
@@ -131,432 +385,930 @@ minetest.register_node("default:desert_sandstone_block", {
 	sounds = default.node_sound_stone_defaults(),
 })
 
-
--- Dirt / Земля (мягкие породы)
-minetest.register_node("default:dirt_with_grass", {
-	description       = S("Dirt with Grass"),
-	tiles             = {
-		"default_grass.png",
-		"default_dirt.png",
-		{ name = "default_dirt.png^default_grass_side.png", tileable_vertical = false }
-	},
-	is_ground_content = true,
-	groups            = { crumbly = 3, soil = 1 },
-	drop              = 'default:dirt',
-	sounds            = default.node_sound_dirt_defaults({
-		footstep = { name = "default_grass_footstep", gain = 0.25 },
-	}),
+minetest.register_node("default:silver_sandstone", {
+	description = S("Silver Sandstone"),
+	tiles = {"default_silver_sandstone.png"},
+	groups = {crumbly = 1, cracky = 3},
+	sounds = default.node_sound_stone_defaults(),
 })
 
-minetest.register_node("default:dirt_with_grass_footsteps", {
-	description       = S("Dirt with Grass and Footsteps"),
-	tiles             = {
-		"default_grass_footsteps.png",
-		"default_dirt.png",
-		{ name = "default_dirt.png^default_grass_side.png", tileable_vertical = false }
-	},
-	is_ground_content = true,
-	groups            = { crumbly = 3, soil = 1, not_in_creative_inventory = 1 },
-	drop              = 'default:dirt',
-	sounds            = default.node_sound_dirt_defaults({
-		footstep = { name = "default_grass_footstep", gain = 0.25 },
-	}),
-})
-
-minetest.register_node("default:dirt_with_snow", {
-	description       = S("Dirt with Snow"),
-	tiles             = {
-		"default_snow.png",
-		"default_dirt.png",
-		{ name = "default_dirt.png^default_snow_side.png", tileable_vertical = false }
-	},
-	is_ground_content = true,
-	groups            = { crumbly = 3 },
-	drop              = 'default:dirt',
-	sounds            = default.node_sound_dirt_defaults({
-		footstep = { name = "default_snow_footstep", gain = 0.15 },
-	}),
-})
-
-minetest.register_node("default:dirt", {
-	description       = S("Dirt"),
-	tiles             = { "default_dirt.png" },
-	is_ground_content = true,
-	groups            = { crumbly = 3, soil = 1 },
-	sounds            = default.node_sound_dirt_defaults(),
-})
-
-local function set_grass(pos)
-	local count_grasses = {};
-	local curr_max      = 0;
-	local curr_type     = "lottmapgen:default_grass";
-
-	local positions     = minetest.find_nodes_in_area({ x = (pos.x - 2), y = (pos.y - 2), z = (pos.z - 2) },
-		{ x = (pos.x + 2), y = (pos.y + 2), z = (pos.z + 2) }, "group:lottmapgen_grass");
-	for _, p in ipairs(positions) do
-		local n = minetest.get_node(p);
-		if (n and n.name) then
-			if (not (count_grasses[n.name])) then
-				count_grasses[n.name] = 1;
-			else
-				count_grasses[n.name] = count_grasses[n.name] + 1;
-			end
-			if (count_grasses[n.name] > curr_max) then
-				curr_max  = count_grasses[n.name];
-				curr_type = n.name;
-			end
-		end
-	end
-	minetest.set_node(pos, { name = curr_type })
-end
-
-minetest.register_abm({
-	nodenames = { "default:dirt" },
-	interval  = 2,
-	chance    = 200,
-	action    = function(pos, node)
-		local above   = { x = pos.x, y = pos.y + 1, z = pos.z }
-		local name    = minetest.get_node(above).name
-		local nodedef = minetest.registered_nodes[name]
-		if nodedef and (nodedef.sunlight_propagates or nodedef.paramtype == "light")
-			and nodedef.liquidtype == "none"
-			and (minetest.get_node_light(above) or 0) >= 13 then
-			if name == "default:snow" or name == "default:snowblock" then
-				minetest.set_node(pos, { name = "default:dirt_with_snow" })
-			else
-				set_grass(pos)
-			end
-		end
-	end
-})
-
-minetest.register_abm({
-	nodenames = { "default:dirt_with_grass" },
-	interval  = 2,
-	chance    = 20,
-	action    = function(pos, node)
-		local above   = { x = pos.x, y = pos.y + 1, z = pos.z }
-		local name    = minetest.get_node(above).name
-		local nodedef = minetest.registered_nodes[name]
-		if name ~= "ignore" and nodedef
-			and not ((nodedef.sunlight_propagates or nodedef.paramtype == "light")
-			and nodedef.liquidtype == "none") then
-			minetest.set_node(pos, { name = "default:dirt" })
-		end
-	end
-})
-
-minetest.register_node("default:sand", {
-	description       = S("Sand"),
-	tiles             = { "default_sand.png" },
-	is_ground_content = true,
-	groups            = { crumbly = 3, falling_node = 1, sand = 1 },
-	sounds            = default.node_sound_sand_defaults(),
-})
-
-minetest.register_node("default:desert_sand", {
-	description       = S("Desert Sand"),
-	tiles             = { "default_desert_sand.png" },
-	is_ground_content = true,
-	groups            = { crumbly = 3, falling_node = 1, sand = 1 },
-	sounds            = default.node_sound_sand_defaults(),
-})
-
-minetest.register_node("default:gravel", {
-	description       = S("Gravel"),
-	tiles             = { "default_gravel.png" },
-	is_ground_content = true,
-	groups            = { crumbly = 2, falling_node = 1 },
-	sounds            = default.node_sound_gravel_defaults(),
-})
-
-minetest.register_node("default:sandstone", {
-	description       = S("Sandstone"),
-	tiles             = { "default_sandstone.png" },
-	is_ground_content = true,
-	groups            = { crumbly = 2, cracky = 3 },
-	sounds            = default.node_sound_stone_defaults(),
-})
-
-minetest.register_node("default:sandstonebrick", {
-	description       = S("Sandstone Brick"),
-	tiles             = { "default_sandstone_brick.png" },
-	is_ground_content = true,
-	groups            = { cracky = 2 },
-	sounds            = default.node_sound_stone_defaults(),
-})
-
-minetest.register_node("default:sandstone_block", {
-	description = S("Sandstone Block"),
-	tiles = {"default_sandstone_block.png"},
+minetest.register_node("default:silver_sandstone_brick", {
+	description = S("Silver Sandstone Brick"),
+	paramtype2 = "facedir",
+	place_param2 = 0,
+	tiles = {"default_silver_sandstone_brick.png"},
 	is_ground_content = false,
 	groups = {cracky = 2},
 	sounds = default.node_sound_stone_defaults(),
 })
 
+minetest.register_node("default:silver_sandstone_block", {
+	description = S("Silver Sandstone Block"),
+	tiles = {"default_silver_sandstone_block.png"},
+	is_ground_content = false,
+	groups = {cracky = 2},
+	sounds = default.node_sound_stone_defaults(),
+})
+
+minetest.register_node("default:obsidian", {
+	description = S("Obsidian"),
+	tiles = {"default_obsidian.png"},
+	sounds = default.node_sound_stone_defaults(),
+	groups = {cracky = 1, level = 2},
+})
+
+minetest.register_node("default:obsidianbrick", {
+	description = S("Obsidian Brick"),
+	paramtype2 = "facedir",
+	place_param2 = 0,
+	tiles = {"default_obsidian_brick.png"},
+	is_ground_content = false,
+	sounds = default.node_sound_stone_defaults(),
+	groups = {cracky = 1, level = 2},
+})
+
+minetest.register_node("default:obsidian_block", {
+	description = S("Obsidian Block"),
+	tiles = {"default_obsidian_block.png"},
+	is_ground_content = false,
+	sounds = default.node_sound_stone_defaults(),
+	groups = {cracky = 1, level = 2},
+})
+
+--
+-- Soft / Non-Stone
+--
+
+minetest.register_node("default:dirt", {
+	description = S("Dirt"),
+	tiles = {"default_dirt.png"},
+	groups = {crumbly = 3, soil = 1},
+	sounds = default.node_sound_dirt_defaults(),
+})
+
+minetest.register_node("default:dirt_with_grass", {
+	description = S("Dirt with Grass"),
+	tiles = {"default_grass.png", "default_dirt.png",
+		{name = "default_dirt.png^default_grass_side.png",
+			tileable_vertical = false}},
+	groups = {crumbly = 3, soil = 1, spreading_dirt_type = 1},
+	drop = "default:dirt",
+	sounds = default.node_sound_dirt_defaults({
+		footstep = {name = "default_grass_footstep", gain = 0.25},
+	}),
+})
+
+minetest.register_node("default:dirt_with_grass_footsteps", {
+	description = S("Dirt with Grass and Footsteps"),
+	tiles = {"default_grass.png^default_footprint.png", "default_dirt.png",
+		{name = "default_dirt.png^default_grass_side.png",
+			tileable_vertical = false}},
+	groups = {crumbly = 3, soil = 1, not_in_creative_inventory = 1},
+	drop = "default:dirt",
+	sounds = default.node_sound_dirt_defaults({
+		footstep = {name = "default_grass_footstep", gain = 0.25},
+	}),
+})
+
+minetest.register_node("default:dirt_with_dry_grass", {
+	description = S("Dirt with Savanna Grass"),
+	tiles = {"default_dry_grass.png",
+		"default_dirt.png",
+		{name = "default_dirt.png^default_dry_grass_side.png",
+			tileable_vertical = false}},
+	groups = {crumbly = 3, soil = 1, spreading_dirt_type = 1},
+	drop = "default:dirt",
+	sounds = default.node_sound_dirt_defaults({
+		footstep = {name = "default_grass_footstep", gain = 0.4},
+	}),
+})
+
+minetest.register_node("default:dirt_with_snow", {
+	description = S("Dirt with Snow"),
+	tiles = {"default_snow.png", "default_dirt.png",
+		{name = "default_dirt.png^default_snow_side.png",
+			tileable_vertical = false}},
+	groups = {crumbly = 3, soil = 1, spreading_dirt_type = 1, snowy = 1},
+	drop = "default:dirt",
+	sounds = default.node_sound_dirt_defaults({
+		footstep = {name = "default_snow_footstep", gain = 0.2},
+	}),
+})
+
+minetest.register_node("default:dirt_with_rainforest_litter", {
+	description = S("Dirt with Rainforest Litter"),
+	tiles = {
+		"default_rainforest_litter.png",
+		"default_dirt.png",
+		{name = "default_dirt.png^default_rainforest_litter_side.png",
+			tileable_vertical = false}
+	},
+	groups = {crumbly = 3, soil = 1, spreading_dirt_type = 1},
+	drop = "default:dirt",
+	sounds = default.node_sound_dirt_defaults({
+		footstep = {name = "default_grass_footstep", gain = 0.4},
+	}),
+})
+
+minetest.register_node("default:dirt_with_coniferous_litter", {
+	description = S("Dirt with Coniferous Litter"),
+	tiles = {
+		"default_coniferous_litter.png",
+		"default_dirt.png",
+		{name = "default_dirt.png^default_coniferous_litter_side.png",
+			tileable_vertical = false}
+	},
+	groups = {crumbly = 3, soil = 1, spreading_dirt_type = 1},
+	drop = "default:dirt",
+	sounds = default.node_sound_dirt_defaults({
+		footstep = {name = "default_grass_footstep", gain = 0.4},
+	}),
+})
+
+minetest.register_node("default:dry_dirt", {
+	description = S("Savanna Dirt"),
+	tiles = {"default_dry_dirt.png"},
+	groups = {crumbly = 3, soil = 1},
+	sounds = default.node_sound_dirt_defaults(),
+})
+
+minetest.register_node("default:dry_dirt_with_dry_grass", {
+	description = S("Savanna Dirt with Savanna Grass"),
+	tiles = {"default_dry_grass.png", "default_dry_dirt.png",
+		{name = "default_dry_dirt.png^default_dry_grass_side.png",
+			tileable_vertical = false}},
+	groups = {crumbly = 3, soil = 1},
+	drop = "default:dry_dirt",
+	sounds = default.node_sound_dirt_defaults({
+		footstep = {name = "default_grass_footstep", gain = 0.4},
+	}),
+})
+
+minetest.register_node("default:permafrost", {
+	description = S("Permafrost"),
+	tiles = {"default_permafrost.png"},
+	groups = {cracky = 3},
+	sounds = default.node_sound_dirt_defaults(),
+})
+
+minetest.register_node("default:permafrost_with_stones", {
+	description = S("Permafrost with Stones"),
+	tiles = {"default_permafrost.png^default_stones.png",
+		"default_permafrost.png",
+		"default_permafrost.png^default_stones_side.png"},
+	groups = {cracky = 3},
+	sounds = default.node_sound_gravel_defaults(),
+})
+
+minetest.register_node("default:permafrost_with_moss", {
+	description = S("Permafrost with Moss"),
+	tiles = {"default_moss.png", "default_permafrost.png",
+		{name = "default_permafrost.png^default_moss_side.png",
+			tileable_vertical = false}},
+	groups = {cracky = 3},
+	sounds = default.node_sound_dirt_defaults({
+		footstep = {name = "default_grass_footstep", gain = 0.25},
+	}),
+})
+
+minetest.register_node("default:sand", {
+	description = S("Sand"),
+	tiles = {"default_sand.png"},
+	groups = {crumbly = 3, falling_node = 1, sand = 1},
+	sounds = default.node_sound_sand_defaults(),
+})
+
+minetest.register_node("default:desert_sand", {
+	description = S("Desert Sand"),
+	tiles = {"default_desert_sand.png"},
+	groups = {crumbly = 3, falling_node = 1, sand = 1},
+	sounds = default.node_sound_sand_defaults(),
+})
+
+minetest.register_node("default:silver_sand", {
+	description = S("Silver Sand"),
+	tiles = {"default_silver_sand.png"},
+	groups = {crumbly = 3, falling_node = 1, sand = 1},
+	sounds = default.node_sound_sand_defaults(),
+})
+
+
+minetest.register_node("default:gravel", {
+	description = S("Gravel"),
+	tiles = {"default_gravel.png"},
+	groups = {crumbly = 2, falling_node = 1},
+	sounds = default.node_sound_gravel_defaults(),
+	drop = {
+		max_items = 1,
+		items = {
+			{items = {"default:flint"}, rarity = 16},
+			{items = {"default:gravel"}}
+		}
+	}
+})
+
 minetest.register_node("default:clay", {
-	description       = S("Clay"),
-	tiles             = { "default_clay.png" },
-	is_ground_content = true,
-	groups            = { crumbly = 3 },
-	drop              = 'default:clay_lump 4',
-	sounds            = default.node_sound_dirt_defaults(),
-})
-
-minetest.register_node("default:brick", {
-	description       = S("Brick Block"),
-	tiles             = { "default_brick.png" },
-	is_ground_content = false,
-	groups            = { cracky = 3 },
-	sounds            = default.node_sound_stone_defaults(),
+	description = S("Clay"),
+	tiles = {"default_clay.png"},
+	groups = {crumbly = 3},
+	drop = "default:clay_lump 4",
+	sounds = default.node_sound_dirt_defaults(),
 })
 
 
--- Wood / Дерево
+minetest.register_node("default:snow", {
+	description = S("Snow"),
+	tiles = {"default_snow.png"},
+	inventory_image = "default_snowball.png",
+	wield_image = "default_snowball.png",
+	paramtype = "light",
+	buildable_to = true,
+	floodable = true,
+	drawtype = "nodebox",
+	node_box = {
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.25, 0.5},
+		},
+	},
+	collision_box = {
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -6 / 16, 0.5},
+		},
+	},
+	groups = {crumbly = 3, falling_node = 1, snowy = 1},
+	sounds = default.node_sound_snow_defaults(),
 
--- яблоня
-minetest.register_node("default:tree_trunk", {
-	description       = S("Tree Тrunk"),
-	tiles             = { "default_tree_top.png", "default_tree_top.png", "default_tree.png" },
-	paramtype2        = "facedir",
-	is_ground_content = false,
-	drop              = "default:tree",
-	groups            = { tree = 1, choppy = 2, oddly_breakable_by_hand = 1, flammable = 2 },
-	sounds            = default.node_sound_wood_defaults(),
-	on_place          = minetest.rotate_node,
-})
-
-minetest.register_node("default:tree", {
-	description       = S("Tree"),
-	tiles             = { "default_tree_top.png", "default_tree_top.png", "default_tree.png" },
-	paramtype2        = "facedir",
-	is_ground_content = false,
-	groups            = { tree = 1, choppy = 2, oddly_breakable_by_hand = 1, flammable = 2 },
-	sounds            = default.node_sound_wood_defaults(),
-	on_place          = function(itemstack, placer, pointed_thing)
-		if pointed_thing.type == "node" and
-			minetest.registered_nodes[minetest.get_node(pointed_thing.above).name].buildable_to == true then
-
-			local p0     = pointed_thing.under  -- куда смотрим
-			local p1     = pointed_thing.above  -- куда ставим
-			local param2 = 0
-			local p3     = { x = p1.x, y = p1.y, z = p1.z }
-			p3.y         = p3.y + 1
-
-			if minetest.is_protected(p1, placer:get_player_name()) or
-				minetest.is_protected(p3, placer:get_player_name()) then
-				minetest.record_protection_violation(p1, placer:get_player_name())
-				return itemstack
-			end
-
-			local placer_pos = placer:getpos()
-			if placer_pos then
-				local x = math.abs(p0.x - p1.x)
-				--local y = math.abs(p0.y - p1.y)
-				local z = math.abs(p0.z - p1.z)
-
-				-- установка по вектору на игрока
-				--if z>x then param2 = 6 else param2 = 13 end
-				-- единичку добавляем что бы получить смещение относительно головы игрока (более реально)
-				--if y+1>math.max(x,z) then param2 = 0 end
-
-				-- установка по грани узла
-				if z ~= 0 then param2 = 6
-				elseif x ~= 0 then param2 = 13
-				else param2 = 0 end
-
-			end
-			minetest.set_node(p1, { name = "default:tree_trunk", param2 = param2 })
-			if not default.creative then
-				itemstack:take_item()
-			end
-			return itemstack
+	on_construct = function(pos)
+		pos.y = pos.y - 1
+		if minetest.get_node(pos).name == "default:dirt_with_grass" then
+			minetest.set_node(pos, {name = "default:dirt_with_snow"})
 		end
 	end,
-	on_dig            = function(pos, node, digger)
-		default.dig_tree(pos, node, "default:tree", digger, 20, 2, "default:tree")
+})
+
+minetest.register_node("default:snowblock", {
+	description = S("Snow Block"),
+	tiles = {"default_snow.png"},
+	groups = {crumbly = 3, cools_lava = 1, snowy = 1},
+	sounds = default.node_sound_snow_defaults(),
+
+	on_construct = function(pos)
+		pos.y = pos.y - 1
+		if minetest.get_node(pos).name == "default:dirt_with_grass" then
+			minetest.set_node(pos, {name = "default:dirt_with_snow"})
+		end
 	end,
+})
+
+-- 'is ground content = false' to avoid tunnels in sea ice or ice rivers
+minetest.register_node("default:ice", {
+	description = S("Ice"),
+	tiles = {"default_ice.png"},
+	is_ground_content = false,
+	paramtype = "light",
+	groups = {cracky = 3, cools_lava = 1, slippery = 3},
+	sounds = default.node_sound_ice_defaults(),
+})
+
+-- Mapgen-placed ice with 'is ground content = true' to contain tunnels
+minetest.register_node("default:cave_ice", {
+	description = S("Cave Ice"),
+	tiles = {"default_ice.png"},
+	paramtype = "light",
+	groups = {cracky = 3, cools_lava = 1, slippery = 3,
+		not_in_creative_inventory = 1},
+	drop = "default:ice",
+	sounds = default.node_sound_ice_defaults(),
+})
+
+--
+-- Trees
+--
+
+minetest.register_node("default:tree", {
+	description = S("Apple Tree"),
+	tiles = {"default_tree_top.png", "default_tree_top.png", "default_tree.png"},
+	paramtype2 = "facedir",
+	is_ground_content = false,
+	groups = {tree = 1, choppy = 2, oddly_breakable_by_hand = 1, flammable = 2},
+	sounds = default.node_sound_wood_defaults(),
+
+	on_place = minetest.rotate_node
 })
 
 minetest.register_node("default:wood", {
-	description = S("Wooden Planks"),
-	tiles       = { "default_wood.png" },
-	groups      = { choppy = 2, oddly_breakable_by_hand = 2, flammable = 3, wood = 1 },
-	sounds      = default.node_sound_wood_defaults(),
-	paramtype2  = "facedir",
+	description = S("Apple Wood Planks"),
+	paramtype2 = "facedir",
+	place_param2 = 0,
+	tiles = {"default_wood.png"},
+	is_ground_content = false,
+	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2, wood = 1},
+	sounds = default.node_sound_wood_defaults(),
 })
 
--- эвкалипт
-minetest.register_node("default:jungletree_trunk", {
-	description       = S("Jungle Tree Trunk"),
-	tiles             = { "default_jungletree_top.png", "default_jungletree_top.png", "default_jungletree.png" },
-	paramtype2        = "facedir",
-	is_ground_content = false,
-	drop              = "default:jungletree",
-	groups            = { tree = 1, choppy = 2, oddly_breakable_by_hand = 1, flammable = 2 },
-	sounds            = default.node_sound_wood_defaults(),
-	on_place          = minetest.rotate_node,
-})
+minetest.register_node("default:sapling", {
+	description = S("Apple Tree Sapling"),
+	drawtype = "plantlike",
+	tiles = {"default_sapling.png"},
+	inventory_image = "default_sapling.png",
+	wield_image = "default_sapling.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	on_timer = grow_sapling,
+	selection_box = {
+		type = "fixed",
+		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 7 / 16, 4 / 16}
+	},
+	groups = {snappy = 2, dig_immediate = 3, flammable = 2,
+		attached_node = 1, sapling = 1},
+	sounds = default.node_sound_leaves_defaults(),
 
-minetest.register_node("default:jungletree", {
-	description       = S("Jungle Tree"),
-	tiles             = { "default_jungletree_top.png", "default_jungletree_top.png", "default_jungletree.png" },
-	paramtype2        = "facedir",
-	is_ground_content = false,
-	groups            = { tree = 1, choppy = 2, oddly_breakable_by_hand = 1, flammable = 2 },
-	sounds            = default.node_sound_wood_defaults(),
-	on_place          = function(itemstack, placer, pointed_thing)
-		if pointed_thing.type == "node" and
-			minetest.registered_nodes[minetest.get_node(pointed_thing.above).name].buildable_to == true then
-
-			local p0     = pointed_thing.under
-			local p1     = pointed_thing.above
-			local param2 = 0
-			local p3     = { x = p1.x, y = p1.y, z = p1.z }
-			p3.y         = p3.y + 1
-
-			if minetest.is_protected(p1, placer:get_player_name()) or
-				minetest.is_protected(p3, placer:get_player_name()) then
-				minetest.record_protection_violation(p1, placer:get_player_name())
-				return itemstack
-			end
-
-			local placer_pos = placer:getpos()
-			if placer_pos then
-				local x = math.abs(p0.x - p1.x)
-				--local y = math.abs(p0.y - p1.y)
-				local z = math.abs(p0.z - p1.z)
-
-				-- установка по вектору на игрока
-				--if z>x then param2 = 6 else param2 = 13 end
-				-- единичку добавляем что бы получить смещение относительно головы игрока (более реально)
-				--if y+1>math.max(x,z) then param2 = 0 end
-
-				-- установка по грани узла
-				if z ~= 0 then param2 = 6
-				elseif x ~= 0 then param2 = 13
-				else param2 = 0 end
-
-			end
-			minetest.set_node(p1, { name = "default:jungletree_trunk", param2 = param2 })
-			if not default.creative then
-				itemstack:take_item()
-			end
-			return itemstack
-		end
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(300, 1500))
 	end,
-	on_dig            = function(pos, node, digger)
-		default.dig_tree(pos, node, "default:jungletree", digger, 12, 5, "default:jungletree")
+
+	on_place = function(itemstack, placer, pointed_thing)
+		itemstack = default.sapling_on_place(itemstack, placer, pointed_thing,
+			"default:sapling",
+			-- minp, maxp to be checked, relative to sapling pos
+			-- minp_relative.y = 1 because sapling pos has been checked
+			{x = -3, y = 1, z = -3},
+			{x = 3, y = 6, z = 3},
+			-- maximum interval of interior volume check
+			4)
+
+		return itemstack
 	end,
-})
-
-minetest.register_node("default:junglewood", {
-	description = S("Junglewood Planks"),
-	tiles       = { "default_junglewood.png" },
-	groups      = { choppy = 2, oddly_breakable_by_hand = 2, flammable = 3, wood = 1 },
-	sounds      = default.node_sound_wood_defaults(),
-	paramtype2  = "facedir",
-})
-
-minetest.register_node("default:jungleleaves", {
-	description       = S("Jungle Leaves"),
-	drawtype          = "mesh",
-	mesh              = "leaves_model.obj",
-	tiles             = { "default_jungleleaves.png" },
-	inventory_image   = "default_jungleleaves_inv.png",
-	paramtype         = "light",
-	is_ground_content = false,
-	walkable          = false,
-	climbable         = true,
-	groups            = { snappy = 3, leafdecay = 3, flammable = 2, leaves = 1 },
-	drop              = {
-		max_items = 1,
-		items     = {
-			{
-				-- player will get sapling with 1/20 chance
-				items  = { 'default:junglesapling' },
-				rarity = 20,
-			},
-			{
-				-- player will get leaves only if he get no saplings,
-				-- this is because max_items is 1
-				items = { 'default:jungleleaves' },
-			}
-		}
-	},
-	sounds            = default.node_sound_leaves_defaults(),
-})
-
-minetest.register_node("default:junglesapling", {
-	description     = S("Jungle Sapling"),
-	drawtype        = "plantlike",
-	visual_scale    = 1.0,
-	tiles           = { "default_junglesapling.png" },
-	inventory_image = "default_junglesapling.png",
-	wield_image     = "default_junglesapling.png",
-	paramtype       = "light",
-	walkable        = false,
-	selection_box   = {
-		type  = "fixed",
-		fixed = { -0.3, -0.5, -0.3, 0.3, 0.35, 0.3 }
-	},
-	groups          = { snappy = 2, dig_immediate = 3, flammable = 2, attached_node = 1, sapling = 1 },
-	sounds          = default.node_sound_leaves_defaults(),
-})
-
-minetest.register_node("default:junglegrass", {
-	description       = S("Jungle Grass"),
-	drawtype          = "plantlike",
-	visual_scale      = 1.3,
-	tiles             = { "default_junglegrass.png" },
-	inventory_image   = "default_junglegrass.png",
-	wield_image       = "default_junglegrass.png",
-	paramtype         = "light",
-	walkable          = false,
-	buildable_to      = true,
-	is_ground_content = true,
-	groups            = { snappy = 3, flammable = 2, flora = 1, attached_node = 1, grass = 1 },
-	sounds            = default.node_sound_leaves_defaults(),
-	selection_box     = {
-		type  = "fixed",
-		fixed = { -0.5, -0.5, -0.5, 0.5, -5 / 16, 0.5 },
-	},
 })
 
 minetest.register_node("default:leaves", {
-	description                = S("Leaves"),
-	drawtype                   = "mesh",
-	mesh                       = "leaves_model.obj",
-	tiles                      = { "default_leaves.png" },
-	inventory_image            = "default_leaves_inv.png",
-	paramtype                  = "light",
-	walkable                   = false,
-	--climbable=true,
-	liquid_viscosity           = 8,
-	liquidtype                 = "source",
-	liquid_alternative_flowing = "default:leaves",
-	liquid_alternative_source  = "default:leaves",
-	liquid_renewable           = false,
-	liquid_range               = 0,
-
-	is_ground_content          = false,
-	groups                     = { snappy = 3, leafdecay = 3, flammable = 2, leaves = 1 },
-	drop                       = {
+	description = S("Apple Tree Leaves"),
+	drawtype = "allfaces_optional",
+	waving = 1,
+	tiles = {"default_leaves.png"},
+	special_tiles = {"default_leaves_simple.png"},
+	paramtype = "light",
+	is_ground_content = false,
+	groups = {snappy = 3, leafdecay = 3, flammable = 2, leaves = 1},
+	drop = {
 		max_items = 1,
-		items     = {
+		items = {
 			{
 				-- player will get sapling with 1/20 chance
-				items  = { 'default:sapling' },
+				items = {"default:sapling"},
 				rarity = 20,
 			},
 			{
 				-- player will get leaves only if he get no saplings,
 				-- this is because max_items is 1
-				items = { 'default:leaves' },
+				items = {"default:leaves"},
 			}
 		}
 	},
-	sounds                     = default.node_sound_leaves_defaults(),
+	sounds = default.node_sound_leaves_defaults(),
+
+	after_place_node = after_place_leaves,
+})
+
+minetest.register_node("default:apple", {
+	description = S("Apple"),
+	drawtype = "plantlike",
+	tiles = {"default_apple.png"},
+	inventory_image = "default_apple.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	is_ground_content = false,
+	selection_box = {
+		type = "fixed",
+		fixed = {-3 / 16, -7 / 16, -3 / 16, 3 / 16, 4 / 16, 3 / 16}
+	},
+	groups = {fleshy = 3, dig_immediate = 3, flammable = 2,
+		leafdecay = 3, leafdecay_drop = 1, food_apple = 1},
+	on_use = minetest.item_eat(2),
+	sounds = default.node_sound_leaves_defaults(),
+
+	after_place_node = function(pos, placer, itemstack)
+		minetest.set_node(pos, {name = "default:apple", param2 = 1})
+	end,
+
+	after_dig_node = function(pos, oldnode, oldmetadata, digger)
+		if oldnode.param2 == 0 then
+			minetest.set_node(pos, {name = "default:apple_mark"})
+			minetest.get_node_timer(pos):start(math.random(300, 1500))
+		end
+	end,
+})
+
+minetest.register_node("default:apple_mark", {
+	description = S("Apple Marker"),
+	inventory_image = "default_apple.png^default_invisible_node_overlay.png",
+	wield_image = "default_apple.png^default_invisible_node_overlay.png",
+	drawtype = "airlike",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	pointable = false,
+	diggable = false,
+	buildable_to = true,
+	drop = "",
+	groups = {not_in_creative_inventory = 1},
+	on_timer = function(pos, elapsed)
+		if not minetest.find_node_near(pos, 1, "default:leaves") then
+			minetest.remove_node(pos)
+		elseif minetest.get_node_light(pos) < 11 then
+			minetest.get_node_timer(pos):start(200)
+		else
+			minetest.set_node(pos, {name = "default:apple"})
+		end
+	end
+})
+
+
+minetest.register_node("default:jungletree", {
+	description = S("Jungle Tree"),
+	tiles = {"default_jungletree_top.png", "default_jungletree_top.png",
+		"default_jungletree.png"},
+	paramtype2 = "facedir",
+	is_ground_content = false,
+	groups = {tree = 1, choppy = 2, oddly_breakable_by_hand = 1, flammable = 2},
+	sounds = default.node_sound_wood_defaults(),
+
+	on_place = minetest.rotate_node
+})
+
+minetest.register_node("default:junglewood", {
+	description = S("Jungle Wood Planks"),
+	paramtype2 = "facedir",
+	place_param2 = 0,
+	tiles = {"default_junglewood.png"},
+	is_ground_content = false,
+	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2, wood = 1},
+	sounds = default.node_sound_wood_defaults(),
+})
+
+minetest.register_node("default:jungleleaves", {
+	description = S("Jungle Tree Leaves"),
+	drawtype = "allfaces_optional",
+	waving = 1,
+	tiles = {"default_jungleleaves.png"},
+	special_tiles = {"default_jungleleaves_simple.png"},
+	paramtype = "light",
+	is_ground_content = false,
+	groups = {snappy = 3, leafdecay = 3, flammable = 2, leaves = 1},
+	drop = {
+		max_items = 1,
+		items = {
+			{items = {"default:junglesapling"}, rarity = 20},
+			{items = {"default:jungleleaves"}}
+		}
+	},
+	sounds = default.node_sound_leaves_defaults(),
+
+	after_place_node = after_place_leaves,
+})
+
+minetest.register_node("default:junglesapling", {
+	description = S("Jungle Tree Sapling"),
+	drawtype = "plantlike",
+	tiles = {"default_junglesapling.png"},
+	inventory_image = "default_junglesapling.png",
+	wield_image = "default_junglesapling.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	on_timer = grow_sapling,
+	selection_box = {
+		type = "fixed",
+		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 7 / 16, 4 / 16}
+	},
+	groups = {snappy = 2, dig_immediate = 3, flammable = 2,
+		attached_node = 1, sapling = 1},
+	sounds = default.node_sound_leaves_defaults(),
+
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(300, 1500))
+	end,
+
+	on_place = function(itemstack, placer, pointed_thing)
+		itemstack = default.sapling_on_place(itemstack, placer, pointed_thing,
+			"default:junglesapling",
+			-- minp, maxp to be checked, relative to sapling pos
+			-- minp_relative.y = 1 because sapling pos has been checked
+			{x = -2, y = 1, z = -2},
+			{x = 2, y = 15, z = 2},
+			-- maximum interval of interior volume check
+			4)
+
+		return itemstack
+	end,
+})
+
+minetest.register_node("default:emergent_jungle_sapling", {
+	description = S("Emergent Jungle Tree Sapling"),
+	drawtype = "plantlike",
+	tiles = {"default_emergent_jungle_sapling.png"},
+	inventory_image = "default_emergent_jungle_sapling.png",
+	wield_image = "default_emergent_jungle_sapling.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	on_timer = grow_sapling,
+	selection_box = {
+		type = "fixed",
+		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 7 / 16, 4 / 16}
+	},
+	groups = {snappy = 2, dig_immediate = 3, flammable = 2,
+		attached_node = 1, sapling = 1},
+	sounds = default.node_sound_leaves_defaults(),
+
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(300, 1500))
+	end,
+
+	on_place = function(itemstack, placer, pointed_thing)
+		itemstack = default.sapling_on_place(itemstack, placer, pointed_thing,
+			"default:emergent_jungle_sapling",
+			-- minp, maxp to be checked, relative to sapling pos
+			{x = -3, y = -5, z = -3},
+			{x = 3, y = 31, z = 3},
+			-- maximum interval of interior volume check
+			4)
+
+		return itemstack
+	end,
+})
+
+
+minetest.register_node("default:pine_tree", {
+	description = S("Pine Tree"),
+	tiles = {"default_pine_tree_top.png", "default_pine_tree_top.png",
+		"default_pine_tree.png"},
+	paramtype2 = "facedir",
+	is_ground_content = false,
+	groups = {tree = 1, choppy = 3, oddly_breakable_by_hand = 1, flammable = 3},
+	sounds = default.node_sound_wood_defaults(),
+
+	on_place = minetest.rotate_node
+})
+
+minetest.register_node("default:pine_wood", {
+	description = S("Pine Wood Planks"),
+	paramtype2 = "facedir",
+	place_param2 = 0,
+	tiles = {"default_pine_wood.png"},
+	is_ground_content = false,
+	groups = {choppy = 3, oddly_breakable_by_hand = 2, flammable = 3, wood = 1},
+	sounds = default.node_sound_wood_defaults(),
+})
+
+minetest.register_node("default:pine_needles",{
+	description = S("Pine Needles"),
+	drawtype = "allfaces_optional",
+	tiles = {"default_pine_needles.png"},
+	waving = 1,
+	paramtype = "light",
+	is_ground_content = false,
+	groups = {snappy = 3, leafdecay = 3, flammable = 2, leaves = 1},
+	drop = {
+		max_items = 1,
+		items = {
+			{items = {"default:pine_sapling"}, rarity = 20},
+			{items = {"default:pine_needles"}}
+		}
+	},
+	sounds = default.node_sound_leaves_defaults(),
+
+	after_place_node = after_place_leaves,
+})
+
+minetest.register_node("default:pine_sapling", {
+	description = S("Pine Tree Sapling"),
+	drawtype = "plantlike",
+	tiles = {"default_pine_sapling.png"},
+	inventory_image = "default_pine_sapling.png",
+	wield_image = "default_pine_sapling.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	on_timer = grow_sapling,
+	selection_box = {
+		type = "fixed",
+		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 7 / 16, 4 / 16}
+	},
+	groups = {snappy = 2, dig_immediate = 3, flammable = 3,
+		attached_node = 1, sapling = 1},
+	sounds = default.node_sound_leaves_defaults(),
+
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(300, 1500))
+	end,
+
+	on_place = function(itemstack, placer, pointed_thing)
+		itemstack = default.sapling_on_place(itemstack, placer, pointed_thing,
+			"default:pine_sapling",
+			-- minp, maxp to be checked, relative to sapling pos
+			-- minp_relative.y = 1 because sapling pos has been checked
+			{x = -2, y = 1, z = -2},
+			{x = 2, y = 14, z = 2},
+			-- maximum interval of interior volume check
+			4)
+
+		return itemstack
+	end,
+})
+
+
+minetest.register_node("default:acacia_tree", {
+	description = S("Acacia Tree"),
+	tiles = {"default_acacia_tree_top.png", "default_acacia_tree_top.png",
+		"default_acacia_tree.png"},
+	paramtype2 = "facedir",
+	is_ground_content = false,
+	groups = {tree = 1, choppy = 2, oddly_breakable_by_hand = 1, flammable = 2},
+	sounds = default.node_sound_wood_defaults(),
+
+	on_place = minetest.rotate_node
+})
+
+minetest.register_node("default:acacia_wood", {
+	description = S("Acacia Wood Planks"),
+	paramtype2 = "facedir",
+	place_param2 = 0,
+	tiles = {"default_acacia_wood.png"},
+	is_ground_content = false,
+	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2, wood = 1},
+	sounds = default.node_sound_wood_defaults(),
+})
+
+minetest.register_node("default:acacia_leaves", {
+	description = S("Acacia Tree Leaves"),
+	drawtype = "allfaces_optional",
+	tiles = {"default_acacia_leaves.png"},
+	special_tiles = {"default_acacia_leaves_simple.png"},
+	waving = 1,
+	paramtype = "light",
+	is_ground_content = false,
+	groups = {snappy = 3, leafdecay = 3, flammable = 2, leaves = 1},
+	drop = {
+		max_items = 1,
+		items = {
+			{items = {"default:acacia_sapling"}, rarity = 20},
+			{items = {"default:acacia_leaves"}}
+		}
+	},
+	sounds = default.node_sound_leaves_defaults(),
+
+	after_place_node = after_place_leaves,
+})
+
+minetest.register_node("default:acacia_sapling", {
+	description = S("Acacia Tree Sapling"),
+	drawtype = "plantlike",
+	tiles = {"default_acacia_sapling.png"},
+	inventory_image = "default_acacia_sapling.png",
+	wield_image = "default_acacia_sapling.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	on_timer = grow_sapling,
+	selection_box = {
+		type = "fixed",
+		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 7 / 16, 4 / 16}
+	},
+	groups = {snappy = 2, dig_immediate = 3, flammable = 2,
+		attached_node = 1, sapling = 1},
+	sounds = default.node_sound_leaves_defaults(),
+
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(300, 1500))
+	end,
+
+	on_place = function(itemstack, placer, pointed_thing)
+		itemstack = default.sapling_on_place(itemstack, placer, pointed_thing,
+			"default:acacia_sapling",
+			-- minp, maxp to be checked, relative to sapling pos
+			-- minp_relative.y = 1 because sapling pos has been checked
+			{x = -4, y = 1, z = -4},
+			{x = 4, y = 7, z = 4},
+			-- maximum interval of interior volume check
+			4)
+
+		return itemstack
+	end,
+})
+
+minetest.register_node("default:aspen_tree", {
+	description = S("Aspen Tree"),
+	tiles = {"default_aspen_tree_top.png", "default_aspen_tree_top.png",
+		"default_aspen_tree.png"},
+	paramtype2 = "facedir",
+	is_ground_content = false,
+	groups = {tree = 1, choppy = 3, oddly_breakable_by_hand = 1, flammable = 3},
+	sounds = default.node_sound_wood_defaults(),
+
+	on_place = minetest.rotate_node
+})
+
+minetest.register_node("default:aspen_wood", {
+	description = S("Aspen Wood Planks"),
+	paramtype2 = "facedir",
+	place_param2 = 0,
+	tiles = {"default_aspen_wood.png"},
+	is_ground_content = false,
+	groups = {choppy = 3, oddly_breakable_by_hand = 2, flammable = 3, wood = 1},
+	sounds = default.node_sound_wood_defaults(),
+})
+
+minetest.register_node("default:aspen_leaves", {
+	description = S("Aspen Tree Leaves"),
+	drawtype = "allfaces_optional",
+	tiles = {"default_aspen_leaves.png"},
+	waving = 1,
+	paramtype = "light",
+	is_ground_content = false,
+	groups = {snappy = 3, leafdecay = 3, flammable = 2, leaves = 1},
+	drop = {
+		max_items = 1,
+		items = {
+			{items = {"default:aspen_sapling"}, rarity = 20},
+			{items = {"default:aspen_leaves"}}
+		}
+	},
+	sounds = default.node_sound_leaves_defaults(),
+
+	after_place_node = after_place_leaves,
+})
+
+minetest.register_node("default:aspen_sapling", {
+	description = S("Aspen Tree Sapling"),
+	drawtype = "plantlike",
+	tiles = {"default_aspen_sapling.png"},
+	inventory_image = "default_aspen_sapling.png",
+	wield_image = "default_aspen_sapling.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	on_timer = grow_sapling,
+	selection_box = {
+		type = "fixed",
+		fixed = {-3 / 16, -0.5, -3 / 16, 3 / 16, 0.5, 3 / 16}
+	},
+	groups = {snappy = 2, dig_immediate = 3, flammable = 3,
+		attached_node = 1, sapling = 1},
+	sounds = default.node_sound_leaves_defaults(),
+
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(300, 1500))
+	end,
+
+	on_place = function(itemstack, placer, pointed_thing)
+		itemstack = default.sapling_on_place(itemstack, placer, pointed_thing,
+			"default:aspen_sapling",
+			-- minp, maxp to be checked, relative to sapling pos
+			-- minp_relative.y = 1 because sapling pos has been checked
+			{x = -2, y = 1, z = -2},
+			{x = 2, y = 12, z = 2},
+			-- maximum interval of interior volume check
+			4)
+
+		return itemstack
+	end,
+})
+
+--
+-- Ores
+--
+
+minetest.register_node("default:stone_with_coal", {
+	description = S("Coal Ore"),
+	tiles = {"default_stone.png^default_mineral_coal.png"},
+	groups = {cracky = 3},
+	drop = "default:coal_lump",
+	sounds = default.node_sound_stone_defaults(),
+})
+
+minetest.register_node("default:coalblock", {
+	description = S("Coal Block"),
+	tiles = {"default_coal_block.png"},
+	is_ground_content = false,
+	groups = {cracky = 3},
+	sounds = default.node_sound_stone_defaults(),
+})
+
+
+minetest.register_node("default:stone_with_iron", {
+	description = S("Iron Ore"),
+	tiles = {"default_stone.png^default_mineral_iron.png"},
+	groups = {cracky = 2},
+	drop = "default:iron_lump",
+	sounds = default.node_sound_stone_defaults(),
+})
+
+minetest.register_node("default:steelblock", {
+	description = S("Steel Block"),
+	tiles = {"default_steel_block.png"},
+	is_ground_content = false,
+	groups = {cracky = 1, level = 2},
+	sounds = default.node_sound_metal_defaults(),
+})
+
+
+minetest.register_node("default:stone_with_copper", {
+	description = S("Copper Ore"),
+	tiles = {"default_stone.png^default_mineral_copper.png"},
+	groups = {cracky = 2},
+	drop = "default:copper_lump",
+	sounds = default.node_sound_stone_defaults(),
+})
+
+minetest.register_node("default:copperblock", {
+	description = S("Copper Block"),
+	tiles = {"default_copper_block.png"},
+	is_ground_content = false,
+	groups = {cracky = 1, level = 2},
+	sounds = default.node_sound_metal_defaults(),
+})
+
+
+minetest.register_node("default:stone_with_tin", {
+	description = S("Tin Ore"),
+	tiles = {"default_stone.png^default_mineral_tin.png"},
+	groups = {cracky = 2},
+	drop = "default:tin_lump",
+	sounds = default.node_sound_stone_defaults(),
+})
+
+minetest.register_node("default:tinblock", {
+	description = S("Tin Block"),
+	tiles = {"default_tin_block.png"},
+	is_ground_content = false,
+	groups = {cracky = 1, level = 2},
+	sounds = default.node_sound_metal_defaults(),
+})
+
+
+minetest.register_node("default:bronzeblock", {
+	description = S("Bronze Block"),
+	tiles = {"default_bronze_block.png"},
+	is_ground_content = false,
+	groups = {cracky = 1, level = 2},
+	sounds = default.node_sound_metal_defaults(),
+})
+
+
+minetest.register_node("default:stone_with_mese", {
+	description = S("Mese Ore"),
+	tiles = {"default_stone.png^default_mineral_mese.png"},
+	groups = {cracky = 1},
+	drop = "default:mese_crystal",
+	sounds = default.node_sound_stone_defaults(),
+})
+
+minetest.register_node("default:mese", {
+	description = S("Mese Block"),
+	tiles = {"default_mese_block.png"},
+	paramtype = "light",
+	groups = {cracky = 1, level = 2},
+	sounds = default.node_sound_stone_defaults(),
+	light_source = 3,
+})
+
+
+minetest.register_node("default:stone_with_gold", {
+	description = S("Gold Ore"),
+	tiles = {"default_stone.png^default_mineral_gold.png"},
+	groups = {cracky = 2},
+	drop = "default:gold_lump",
+	sounds = default.node_sound_stone_defaults(),
+})
+
+minetest.register_node("default:goldblock", {
+	description = S("Gold Block"),
+	tiles = {"default_gold_block.png"},
+	is_ground_content = false,
+	groups = {cracky = 1},
+	sounds = default.node_sound_metal_defaults(),
+})
+
+
+minetest.register_node("default:stone_with_diamond", {
+	description = S("Diamond Ore"),
+	tiles = {"default_stone.png^default_mineral_diamond.png"},
+	groups = {cracky = 1},
+	drop = "default:diamond",
+	sounds = default.node_sound_stone_defaults(),
+})
+
+minetest.register_node("default:diamondblock", {
+	description = S("Diamond Block"),
+	tiles = {"default_diamond_block.png"},
+	is_ground_content = false,
+	groups = {cracky = 1, level = 3},
+	sounds = default.node_sound_stone_defaults(),
 })
 
 --
@@ -565,39 +1317,12 @@ minetest.register_node("default:leaves", {
 
 minetest.register_node("default:cactus", {
 	description = S("Cactus"),
-	drawtype = "nodebox",
-	tiles = {"default_cactus_top.png", "default_cactus_bottom.png", "default_cactus_side.png",
-	"default_cactus_side.png","default_cactus_side.png","default_cactus_side.png"},
-	is_ground_content = true,
-	groups = {snappy=1, choppy=3, flammable=2, plant=1, oddly_breakable_by_hand=1},
-	sounds = default.node_sound_leaves_defaults(),
-	paramtype = "light",
-	sunlight_propagates = true,
-	drop = "flowers:cactus_decor",
-	node_placement_prediction = "",
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-7/16, -8/16, -7/16,  7/16, 8/16,  7/16}, -- Main body
-			{-8/16, -8/16, -7/16,  8/16, 8/16, -7/16}, -- Spikes
-			{-8/16, -8/16,  7/16,  8/16, 8/16,  7/16}, -- Spikes
-			{-7/16, -8/16, -8/16, -7/16, 8/16,  8/16}, -- Spikes
-			{7/16,  -8/16,  8/16,  7/16, 8/16, -8/16}, -- Spikes
-		},
-	},
-	collision_box = {
-		type = "fixed",
-		fixed = {-7/16, -8/16, -7/16,  7/16, 7/16,  7/16}, -- Main body
-	},
-	selection_box = {
-		type = "fixed",
-		fixed = {
-			{-7/16, -8/16, -7/16, 7/16, 8/16, 7/16},
-		},
-	},
-	after_dig_node = function(pos, node, metadata, digger)
-		default.dig_up(pos, node, digger)
-	end,
+	tiles = {"default_cactus_top.png", "default_cactus_top.png",
+		"default_cactus_side.png"},
+	paramtype2 = "facedir",
+	groups = {choppy = 3},
+	sounds = default.node_sound_wood_defaults(),
+	on_place = minetest.rotate_node,
 })
 
 minetest.register_node("default:large_cactus_seedling", {
@@ -672,813 +1397,121 @@ minetest.register_node("default:large_cactus_seedling", {
 })
 
 minetest.register_node("default:papyrus", {
-	description       = S("Papyrus"),
-	drawtype          = "plantlike",
-	tiles             = { "default_papyrus.png" },
-	inventory_image   = "default_papyrus.png",
-	wield_image       = "default_papyrus.png",
-	paramtype         = "light",
-	walkable          = false,
-	is_ground_content = true,
-	selection_box     = {
-		type  = "fixed",
-		fixed = { -0.3, -0.5, -0.3, 0.3, 0.5, 0.3 }
+	description = S("Papyrus"),
+	drawtype = "plantlike",
+	tiles = {"default_papyrus.png"},
+	inventory_image = "default_papyrus.png",
+	wield_image = "default_papyrus.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	selection_box = {
+		type = "fixed",
+		fixed = {-6 / 16, -0.5, -6 / 16, 6 / 16, 0.5, 6 / 16},
 	},
-	groups            = { snappy = 3, flammable = 2, grass = 1 },
-	sounds            = default.node_sound_leaves_defaults(),
+	groups = {snappy = 3, flammable = 2},
+	sounds = default.node_sound_leaves_defaults(),
+
 	after_dig_node = function(pos, node, metadata, digger)
 		default.dig_up(pos, node, digger)
 	end,
 })
 
-default.bookshelf_formspec = --[[
-	"size[8,7;]"..
-	"list[context;books;0,0.3;8,2;]"..
-	"list[current_player;main;0,2.85;8,1;]"..
-	"list[current_player;main;0,4.08;8,3;8]"
-]]--
-"size[8,9]" ..
-	"list[context;books;0,0;8,2;]" ..
-	"list[current_player;main;0,5;8,4;]" ..
-	"listring[context;books]" ..
-	"listring[current_player;main]" ..
-	"background[-0.5,-0.65;9,10.35;gui_chestbg.png]" ..
-	"listcolors[#606060AA;#888;#141318;#30434C;#FFF]"
-
-minetest.register_node("default:bookshelf", {
-	description                   = S("Bookshelf"),
-	drawtype                      = "mesh",
-	mesh                          = "3dbookshelf.obj",
-	tiles                         = {
-		"default_wood.png",
-		"default_wood.png^3dbookshelf_inside_back.png",
-		"3dbookshelf_books.png",
-	},
-	paramtype                     = "light",
-	paramtype2                    = "facedir",
-	is_ground_content             = false,
-	groups                        = { choppy = 3, oddly_breakable_by_hand = 2, flammable = 3, wooden = 1 },
-	sounds                        = default.node_sound_wood_defaults(),
-	on_construct                  = function(pos)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", S("Bookshelf"))
-		meta:set_string("formspec", default.bookshelf_formspec)
-		local inv = meta:get_inventory()
-		inv:set_size("books", 8 * 2)
-	end,
-	can_dig                       = function(pos, player)
-		local meta = minetest.get_meta(pos);
-		local inv  = meta:get_inventory()
-		return inv:is_empty("books")
-	end,
-	allow_metadata_inventory_put  = function(pos, listname, index, stack, player)
-		if listname == "books" then
-			if stack:get_definition().groups["book"] == 1 then
-				return 1
-			else
-				return 0
-			end
-		end
-	end,
-	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
-		local meta     = minetest.get_meta(pos)
-		local inv      = meta:get_inventory()
-		local stack    = inv:get_stack(from_list, from_index)
-		local to_stack = inv:get_stack(to_list, to_index)
-		if to_list == "books" then
-			if stack:get_definition().groups["book"] == 1 and to_stack:is_empty() then
-				return 1
-			else
-				return 0
-			end
-		end
-	end,
-	on_metadata_inventory_move    = function(pos, from_list, from_index, to_list, to_index, count, player)
-		minetest.log("action", player:get_player_name() ..
-			" moves stuff in bookshelf at " .. minetest.pos_to_string(pos))
-	end,
-	on_metadata_inventory_put     = function(pos, listname, index, stack, player)
-		minetest.log("action", player:get_player_name() ..
-			" moves stuff to bookshelf at " .. minetest.pos_to_string(pos))
-	end,
-	on_metadata_inventory_take    = function(pos, listname, index, stack, player)
-		minetest.log("action", player:get_player_name() ..
-			" takes stuff from bookshelf at " .. minetest.pos_to_string(pos))
-	end,
-})
-
-minetest.register_node("default:glass", {
-	description         = S("Glass"),
-	drawtype            = "glasslike_framed_optional",
-	tiles               = { "default_glass.png", "default_glass_detail.png" },
-	inventory_image     = minetest.inventorycube("default_glass.png"),
-	paramtype           = "light",
-	sunlight_propagates = true,
-	is_ground_content   = false,
-	groups              = { cracky = 3, oddly_breakable_by_hand = 3 },
-	sounds              = default.node_sound_glass_defaults(),
-})
-
-minetest.register_node("default:fence_wood", {
-	description       = S("Wooden Fence"),
-	drawtype          = "fencelike",
-	tiles             = { "default_wood.png" },
-	inventory_image   = "default_fence.png",
-	wield_image       = "default_fence.png",
-	paramtype         = "light",
-	is_ground_content = false,
-	selection_box     = {
-		type  = "fixed",
-		fixed = { -1 / 7, -1 / 2, -1 / 7, 1 / 7, 1 / 2, 1 / 7 },
-	},
-	collision_box     = {
-		type  = "fixed",
-		fixed = { -1 / 2, -1 / 2, -1 / 2, 1 / 2, 1, 1 / 2 },
-	},
-	groups            = { choppy = 2, oddly_breakable_by_hand = 2, flammable = 2, wooden = 1 },
-	sounds            = default.node_sound_wood_defaults(),
-})
--- временно перенесено сюда при обновлении `crafting.lua`.
--- в `nodes.lua` находится примерно тут
-minetest.register_craft({
-	output = "default:fence_wood 6",
-	recipe = {
-		{"default:wood", "default:wood", "default:wood"},
-		{"default:wood", "default:wood", "default:wood"},
-	}
-})
-
-
-minetest.register_node("default:ladder_wood", {
-	description        = S("Ladder"),
-	drawtype           = "signlike",
-	tiles              = { "default_ladder_wood.png" },
-	inventory_image    = "default_ladder_wood.png",
-	wield_image        = "default_ladder_wood.png",
-	paramtype          = "light",
-	paramtype2         = "wallmounted",
-	walkable           = false,
-	climbable          = true,
-	is_ground_content  = false,
-	selection_box      = {
-		type = "wallmounted",
-		--wall_top = = <default>
-		--wall_bottom = = <default>
-		--wall_side = = <default>
-	},
-	groups             = { choppy = 2, oddly_breakable_by_hand = 3, flammable = 2, wooden = 1 },
-	legacy_wallmounted = true,
-	sounds             = default.node_sound_wood_defaults(),
-})
-
-minetest.register_node("default:cloud", {
-	description = S("Cloud"),
-	tiles       = { "default_cloud.png" },
-	sounds      = default.node_sound_defaults(),
-	groups      = { not_in_creative_inventory = 1 },
-})
-
-minetest.register_node("default:water_flowing", {
-	description                = S("Flowing Water"),
-	inventory_image            = minetest.inventorycube("default_water.png"),
-	drawtype                   = "flowingliquid",
-	tiles                      = { "default_water.png" },
-	special_tiles              = {
-		{
-			image            = "default_water_flowing_animated.png",
-			backface_culling = false,
-			animation        = { type = "vertical_frames", aspect_w = 16, aspect_h = 16, length = 0.8 }
-		},
-		{
-			image            = "default_water_flowing_animated.png",
-			backface_culling = true,
-			animation        = { type = "vertical_frames", aspect_w = 16, aspect_h = 16, length = 0.8 }
-		},
-	},
-	alpha                      = WATER_ALPHA,
-	paramtype                  = "light",
-	paramtype2                 = "flowingliquid",
-	walkable                   = false,
-	pointable                  = false,
-	diggable                   = false,
-	buildable_to               = true,
-	drop                       = "",
-	drowning                   = 1,
-	liquidtype                 = "flowing",
-	liquid_alternative_flowing = "default:water_flowing",
-	liquid_alternative_source  = "default:water_source",
-	liquid_viscosity           = WATER_VISC,
-	freezemelt                 = "default:snow",
-	post_effect_color          = { a = 64, r = 100, g = 100, b = 200 },
-	groups                     = {
-		water                     = 3,
-		liquid                    = 3,
-		puts_out_fire             = 1,
-		not_in_creative_inventory = 1,
-		freezes                   = 1,
-		melt_around               = 1
-	},
-})
-
-minetest.register_node("default:water_source", {
-	description                = S("Water Source"),
-	inventory_image            = minetest.inventorycube("default_water.png"),
-	drawtype                   = "liquid",
-	tiles                      = {
-		{
-			name      = "default_water_source_animated.png",
-			animation = { type = "vertical_frames", aspect_w = 16, aspect_h = 16, length = 2.0 }
-		}
-	},
-	special_tiles              = {
-		-- New-style water source material (mostly unused)
-		{
-			name             = "default_water_source_animated.png",
-			animation        = { type = "vertical_frames", aspect_w = 16, aspect_h = 16, length = 2.0 },
-			backface_culling = false,
-		}
-	},
-	alpha                      = WATER_ALPHA,
-	paramtype                  = "light",
-	walkable                   = false,
-	pointable                  = false,
-	diggable                   = false,
-	buildable_to               = true,
-	drop                       = "",
-	drowning                   = 1,
-	liquidtype                 = "source",
-	liquid_alternative_flowing = "default:water_flowing",
-	liquid_alternative_source  = "default:water_source",
-	liquid_viscosity           = WATER_VISC,
-	freezemelt                 = "default:ice",
-	post_effect_color          = { a = 64, r = 100, g = 100, b = 200 },
-	groups                     = { water = 3, liquid = 3, puts_out_fire = 1, freezes = 1 },
-})
-
-minetest.register_node("default:river_water_source", {
-	description                = S("River Water Source"),
-	inventory_image            = minetest.inventorycube("default_river_water.png"),
-	drawtype                   = "liquid",
-	tiles                      = {
-		{
-			name      = "default_river_water_source_animated.png",
-			animation = {
-				type     = "vertical_frames",
-				aspect_w = 16,
-				aspect_h = 16,
-				length   = 2.0,
-			},
-		},
-	},
-	special_tiles              = {
-		{
-			name             = "default_river_water_source_animated.png",
-			animation        = {
-				type     = "vertical_frames",
-				aspect_w = 16,
-				aspect_h = 16,
-				length   = 2.0,
-			},
-			backface_culling = false,
-		},
-	},
-	alpha                      = 160,
-	paramtype                  = "light",
-	walkable                   = false,
-	pointable                  = false,
-	diggable                   = false,
-	buildable_to               = true,
-	is_ground_content          = false,
-	drop                       = "",
-	drowning                   = 1,
-	liquidtype                 = "source",
-	liquid_alternative_flowing = "default:river_water_flowing",
-	liquid_alternative_source  = "default:river_water_source",
-	liquid_viscosity           = 1,
-	liquid_renewable           = false,
-	liquid_range               = 2,
-	post_effect_color          = { a = 120, r = 30, g = 76, b = 90 },
-	groups                     = { water = 3, liquid = 3, puts_out_fire = 1 },
-})
-
-minetest.register_node("default:river_water_flowing", {
-	description                = S("Flowing River Water"),
-	inventory_image            = minetest.inventorycube("default_river_water.png"),
-	drawtype                   = "flowingliquid",
-	tiles                      = { "default_river_water.png" },
-	special_tiles              = {
-		{
-			name             = "default_river_water_flowing_animated.png",
-			backface_culling = false,
-			animation        = {
-				type     = "vertical_frames",
-				aspect_w = 16,
-				aspect_h = 16,
-				length   = 0.8,
-			},
-		},
-		{
-			name             = "default_river_water_flowing_animated.png",
-			backface_culling = true,
-			animation        = {
-				type     = "vertical_frames",
-				aspect_w = 16,
-				aspect_h = 16,
-				length   = 0.8,
-			},
-		},
-	},
-	alpha                      = 160,
-	paramtype                  = "light",
-	paramtype2                 = "flowingliquid",
-	walkable                   = false,
-	pointable                  = false,
-	diggable                   = false,
-	buildable_to               = true,
-	is_ground_content          = false,
-	drop                       = "",
-	drowning                   = 1,
-	liquidtype                 = "flowing",
-	liquid_alternative_flowing = "default:river_water_flowing",
-	liquid_alternative_source  = "default:river_water_source",
-	liquid_viscosity           = 1,
-	liquid_renewable           = false,
-	liquid_range               = 2,
-	post_effect_color          = { a = 120, r = 30, g = 76, b = 90 },
-	groups                     = { water                     = 3, liquid = 3, puts_out_fire = 1,
-								   not_in_creative_inventory = 1 },
-})
-
-minetest.register_node("default:lava_flowing", {
-	description                = S("Flowing Lava"),
-	inventory_image            = minetest.inventorycube("default_lava.png"),
-	drawtype                   = "flowingliquid",
-	tiles                      = { "default_lava.png" },
-	special_tiles              = {
-		{
-			image            = "default_lava_flowing_animated.png",
-			backface_culling = false,
-			animation        = { type = "vertical_frames", aspect_w = 16, aspect_h = 16, length = 3.3 }
-		},
-		{
-			image            = "default_lava_flowing_animated.png",
-			backface_culling = true,
-			animation        = { type = "vertical_frames", aspect_w = 16, aspect_h = 16, length = 3.3 }
-		},
-	},
-	paramtype                  = "light",
-	paramtype2                 = "flowingliquid",
-	light_source               = LIGHT_MAX - 1,
-	walkable                   = false,
-	pointable                  = false,
-	diggable                   = false,
-	buildable_to               = true,
-	drop                       = "",
-	drowning                   = 1,
-	liquidtype                 = "flowing",
-	liquid_alternative_flowing = "default:lava_flowing",
-	liquid_alternative_source  = "default:lava_source",
-	liquid_viscosity           = LAVA_VISC,
-	liquid_renewable           = false,
-	damage_per_second          = 4 * 2,
-	post_effect_color          = { a = 192, r = 255, g = 64, b = 0 },
-	groups                     = { lava = 3, liquid = 2, hot = 3, igniter = 1, not_in_creative_inventory = 1 },
-})
-
-minetest.register_node("default:lava_source", {
-	description                = S("Lava Source"),
-	inventory_image            = minetest.inventorycube("default_lava.png"),
-	drawtype                   = "liquid",
-	tiles                      = {
-		{
-			name      = "default_lava_source_animated.png",
-			animation = { type = "vertical_frames", aspect_w = 16, aspect_h = 16, length = 3.0 }
-		}
-	},
-	special_tiles              = {
-		-- New-style lava source material (mostly unused)
-		{
-			name             = "default_lava_source_animated.png",
-			animation        = { type = "vertical_frames", aspect_w = 16, aspect_h = 16, length = 3.0 },
-			backface_culling = false,
-		}
-	},
-	paramtype                  = "light",
-	light_source               = LIGHT_MAX - 1,
-	walkable                   = false,
-	pointable                  = false,
-	diggable                   = false,
-	buildable_to               = true,
-	drop                       = "",
-	drowning                   = 1,
-	liquidtype                 = "source",
-	liquid_alternative_flowing = "default:lava_flowing",
-	liquid_alternative_source  = "default:lava_source",
-	liquid_viscosity           = LAVA_VISC,
-	liquid_renewable           = false,
-	damage_per_second          = 4 * 2,
-	post_effect_color          = { a = 192, r = 255, g = 64, b = 0 },
-	groups                     = { lava = 3, liquid = 2, hot = 3, igniter = 1 },
-})
-
-
-minetest.register_node("default:sign_wall", {
-	description         = S("Sign"),
-	drawtype            = "signlike",
-	tiles               = { "default_sign_wall.png" },
-	inventory_image     = "default_sign_wall.png",
-	wield_image         = "default_sign_wall.png",
-	paramtype           = "light",
-	paramtype2          = "wallmounted",
-	sunlight_propagates = true,
-	is_ground_content   = false,
-	walkable            = false,
-	selection_box       = {
-		type = "wallmounted",
-		--wall_top = <default>
-		--wall_bottom = <default>
-		--wall_side = <default>
-	},
-	groups              = { choppy = 2, dig_immediate = 2, attached_node = 1, wooden = 1 },
-	legacy_wallmounted  = true,
-	sounds              = default.node_sound_defaults(),
-	on_construct        = function(pos)
-		--local n = minetest.get_node(pos)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("formspec", "field[text;;${text}]")
-		meta:set_string("infotext", "\"\"")
-	end,
-	on_receive_fields   = function(pos, formname, fields, sender)
-		--print("Sign at "..minetest.pos_to_string(pos).." got "..dump(fields))
-		if minetest.is_protected(pos, sender:get_player_name()) then
-			minetest.record_protection_violation(pos, sender:get_player_name())
-			return
-		end
-		local meta  = minetest.get_meta(pos)
-		fields.text = fields.text or ""
-		minetest.log("action", (sender:get_player_name() or "") .. " wrote \"" .. fields.text ..
-			"\" to sign at " .. minetest.pos_to_string(pos))
-		meta:set_string("text", fields.text)
-		meta:set_string("infotext", '"' .. fields.text .. '"')
-	end,
-})
-
-default.chest_formspec = "size[8,9]" ..
-	"list[current_name;main;0,0;8,4;]" ..
-	"list[current_player;main;0,5;8,4;]" ..
-	"listring[current_name;main]" ..
-	"listring[current_player;main]" ..
-	"background[-0.5,-0.65;9,10.35;gui_chestbg.png]" ..
-	"listcolors[#606060AA;#888;#141318;#30434C;#FFF]"
-
--- кандидат на выпиливание (на данный момент используется только в `lottblocks/chests.lua`)
--- использовать взамен `default.chest.get_chest_formspec()`,
---     переопределённый в `mods/lord/_overwrites/MTG/default/init.lua`
-function default.get_chest_formspec(pos, image)
-	local spos     = pos.x .. "," .. pos.y .. "," .. pos.z
-	local formspec = "size[8,9]" ..
-		"list[nodemeta:" .. spos .. ";main;0,0;8,4;]" ..
-		"list[current_player;main;0,5;8,4;]" ..
-		"listring[nodemeta:" .. spos .. ";main]" ..
-		"listring[current_player;main]" ..
-		"background[-0.5,-0.65;9,10.35;" .. image .. "]" ..
-		"listcolors[#606060AA;#888;#141318;#30434C;#FFF]"
-	return formspec
-end
-
-
-minetest.register_node("default:cobble", {
-	description       = S("Cobblestone"),
-	tiles             = { "default_cobble.png" },
-	is_ground_content = true,
-	groups            = { cracky = 3, stone = 2 },
-	sounds            = default.node_sound_stone_defaults(),
-})
-
-minetest.register_node("default:desert_cobble", {
-	description       = S("Desert Cobble"),
-	tiles             = { "default_desert_cobble.png" },
-	is_ground_content = true,
-	groups            = { cracky = 3, stone = 2 },
-	sounds            = default.node_sound_stone_defaults(),
-})
-
-minetest.register_node("default:mossycobble", {
-	description       = S("Mossy Cobblestone"),
-	tiles             = { "default_mossycobble.png" },
-	is_ground_content = true,
-	groups            = { cracky = 3 },
-	sounds            = default.node_sound_stone_defaults(),
-})
-
-minetest.register_node("default:coalblock", {
-	description       = S("Coal Block"),
-	tiles             = { "default_coal_block.png" },
-	is_ground_content = true,
-	groups            = { cracky = 3, flammable = 10 },
-	sounds            = default.node_sound_stone_defaults(),
-	on_punch          = function(pos, node, puncher)
-		if puncher:get_wielded_item():get_name() == "default:torch" then
-			local pos_above = { x = pos.x, y = pos.y + 1, z = pos.z }
-			if minetest.get_node(pos_above).name == "air" then
-				minetest.set_node(pos_above, { name = "fire:basic_flame" })
-			end
-		end
-	end,
-})
-
-minetest.register_node("default:steelblock", {
-	description       = S("Steel Block"),
-	tiles             = { "default_steel_block.png" },
-	is_ground_content = true,
-	groups            = { cracky = 1, level = 2 },
-	sounds            = default.node_sound_metal_defaults(),
-})
-
-minetest.register_node("default:copperblock", {
-	description       = S("Copper Block"),
-	tiles             = { "default_copper_block.png" },
-	is_ground_content = true,
-	groups            = { cracky = 1, level = 2 },
-	sounds            = default.node_sound_metal_defaults(),
-})
-
-minetest.register_node("default:bronzeblock", {
-	description       = S("Bronze Block"),
-	tiles             = { "default_bronze_block.png" },
-	is_ground_content = true,
-	groups            = { cracky = 1, level = 2 },
-	sounds            = default.node_sound_metal_defaults(),
-})
-
-minetest.register_node("default:mese", {
-	description       = S("Mese Block"),
-	tiles             = { "default_mese_block.png" },
-	is_ground_content = true,
-	groups            = { cracky = 1, level = 2 },
-	sounds            = default.node_sound_glass_defaults(),
-})
-minetest.register_alias("default:mese_block", "default:mese")
-
-minetest.register_node("default:goldblock", {
-	description       = S("Gold Block"),
-	tiles             = { "default_gold_block.png" },
-	is_ground_content = true,
-	groups            = { cracky = 1 },
-	sounds            = default.node_sound_metal_defaults(),
-})
-
-minetest.register_node("default:diamondblock", {
-	description       = S("Diamond Block"),
-	tiles             = { "default_diamond_block.png" },
-	is_ground_content = true,
-	groups            = { cracky = 1, level = 3 },
-	sounds            = default.node_sound_glass_defaults(),
-})
-
-minetest.register_node("default:obsidian_glass", {
-	description         = S("Obsidian Glass"),
-	drawtype            = "glasslike_framed_optional",
-	tiles               = { "default_obsidian_glass.png", "default_obsidian_glass_detail.png" },
-	paramtype           = "light",
-	is_ground_content   = false,
-	sunlight_propagates = true,
-	sounds              = default.node_sound_glass_defaults(),
-	groups              = { cracky = 3, oddly_breakable_by_hand = 3 },
-})
-
-minetest.register_node("default:obsidian", {
-	description       = S("Obsidian"),
-	tiles             = { "default_obsidian.png" },
-	is_ground_content = true,
-	sounds            = default.node_sound_stone_defaults(),
-	groups            = { cracky = 1, level = 2 },
-})
-
-minetest.register_node("default:obsidianbrick", {
-	description = S("Obsidian Brick"),
-	paramtype2 = "facedir",
-	place_param2 = 0,
-	tiles = {"default_obsidian_brick.png"},
-	is_ground_content = false,
-	sounds = default.node_sound_stone_defaults(),
-	groups = {cracky = 1, level = 2},
-})
-
-minetest.register_node("default:obsidian_block", {
-	description = S("Obsidian Block"),
-	tiles = {"default_obsidian_block.png"},
-	is_ground_content = false,
-	sounds = default.node_sound_stone_defaults(),
-	groups = {cracky = 1, level = 2},
-})
-
-minetest.register_node("default:nyancat", {
-	description           = S("Nyan Cat"),
-	tiles                 = { "default_nc_side.png", "default_nc_side.png", "default_nc_side.png",
-							  "default_nc_side.png", "default_nc_back.png", "default_nc_front.png" },
-	paramtype2            = "facedir",
-	groups                = { cracky = 2 },
-	is_ground_content     = false,
-	legacy_facedir_simple = true,
-	sounds                = default.node_sound_defaults(),
-})
-
-minetest.register_node("default:nyancat_rainbow", {
-	description       = S("Nyan Cat Rainbow"),
-	tiles             = { "default_nc_rb.png^[transformR90", "default_nc_rb.png^[transformR90",
-						  "default_nc_rb.png", "default_nc_rb.png" },
-	paramtype2        = "facedir",
-	groups            = { cracky = 2 },
-	is_ground_content = false,
-	sounds            = default.node_sound_defaults(),
-})
-
-minetest.register_node("default:sapling", {
-	description       = S("Sapling"),
-	drawtype          = "plantlike",
-	visual_scale      = 1.0,
-	tiles             = { "default_sapling.png" },
-	inventory_image   = "default_sapling.png",
-	wield_image       = "default_sapling.png",
-	paramtype         = "light",
-	walkable          = false,
-	is_ground_content = true,
-	selection_box     = {
-		type  = "fixed",
-		fixed = { -0.3, -0.5, -0.3, 0.3, 0.35, 0.3 }
-	},
-	groups            = { snappy = 2, dig_immediate = 3, flammable = 2, attached_node = 1, sapling = 1 },
-	sounds            = default.node_sound_leaves_defaults(),
-})
-
-minetest.register_node("default:apple", {
-	description         = S("Apple"),
-	drawtype            = "plantlike",
-	visual_scale        = 1.0,
-	tiles               = { "default_apple.png" },
-	inventory_image     = "default_apple.png",
-	paramtype           = "light",
-	sunlight_propagates = true,
-	walkable            = false,
-	is_ground_content   = true,
-	selection_box       = {
-		type  = "fixed",
-		fixed = { -0.2, -0.5, -0.2, 0.2, 0, 0.2 }
-	},
-	groups              = { fleshy = 3, dig_immediate = 3, flammable = 2, leafdecay = 3, leafdecay_drop = 1 },
-	on_use              = minetest.item_eat(1),
-	sounds              = default.node_sound_leaves_defaults(),
-	after_place_node    = function(pos, placer, itemstack)
-		if placer:is_player() then
-			minetest.set_node(pos, { name = "default:apple", param2 = 1 })
-		end
-	end,
-})
-
 minetest.register_node("default:dry_shrub", {
-	description       = S("Dry Shrub"),
-	drawtype          = "plantlike",
-	visual_scale      = 1.0,
-	tiles             = { "default_dry_shrub.png" },
-	inventory_image   = "default_dry_shrub.png",
-	wield_image       = "default_dry_shrub.png",
-	paramtype         = "light",
-	waving            = 1,
-	walkable          = false,
-	is_ground_content = true,
-	buildable_to      = true,
-	groups            = { snappy = 3, flammable = 3, attached_node = 1, grass = 1 },
-	sounds            = default.node_sound_leaves_defaults(),
-	selection_box     = {
-		type  = "fixed",
-		fixed = { -0.5, -0.5, -0.5, 0.5, -5 / 16, 0.5 },
+	description = S("Dry Shrub"),
+	drawtype = "plantlike",
+	waving = 1,
+	tiles = {"default_dry_shrub.png"},
+	inventory_image = "default_dry_shrub.png",
+	wield_image = "default_dry_shrub.png",
+	paramtype = "light",
+	paramtype2 = "meshoptions",
+	place_param2 = 4,
+	sunlight_propagates = true,
+	walkable = false,
+	buildable_to = true,
+	groups = {snappy = 3, flammable = 3, attached_node = 1},
+	sounds = default.node_sound_leaves_defaults(),
+	selection_box = {
+		type = "fixed",
+		fixed = {-6 / 16, -0.5, -6 / 16, 6 / 16, 4 / 16, 6 / 16},
 	},
 })
+
+minetest.register_node("default:junglegrass", {
+	description = S("Jungle Grass"),
+	drawtype = "plantlike",
+	waving = 1,
+	visual_scale = 1.69,
+	tiles = {"default_junglegrass.png"},
+	inventory_image = "default_junglegrass.png",
+	wield_image = "default_junglegrass.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	buildable_to = true,
+	groups = {snappy = 3, flora = 1, attached_node = 1, grass = 1, junglegrass = 1, flammable = 1},
+	sounds = default.node_sound_leaves_defaults(),
+	selection_box = {
+		type = "fixed",
+		fixed = {-6 / 16, -0.5, -6 / 16, 6 / 16, 0.5, 6 / 16},
+	},
+})
+
 
 minetest.register_node("default:grass_1", {
-	description       = S("Grass"),
-	drawtype          = "plantlike",
-	tiles             = { "default_grass_1.png" },
-	-- use a bigger inventory image
-	inventory_image   = "default_grass_3.png",
-	wield_image       = "default_grass_3.png",
-	paramtype         = "light",
-	walkable          = false,
-	is_ground_content = true,
-	buildable_to      = true,
-	groups            = { snappy = 3, flammable = 3, flora = 1, attached_node = 1, grass = 1, color_green = 1 },
-	sounds            = default.node_sound_leaves_defaults(),
-	selection_box     = {
-		type  = "fixed",
-		fixed = { -0.5, -0.5, -0.5, 0.5, -5 / 16, 0.5 },
+	description = S("Grass"),
+	drawtype = "plantlike",
+	waving = 1,
+	tiles = {"default_grass_1.png"},
+	-- Use texture of a taller grass stage in inventory
+	inventory_image = "default_grass_3.png",
+	wield_image = "default_grass_3.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	buildable_to = true,
+	groups = {snappy = 3, flora = 1, attached_node = 1, grass = 1,
+		normal_grass = 1, flammable = 1},
+	sounds = default.node_sound_leaves_defaults(),
+	selection_box = {
+		type = "fixed",
+		fixed = {-6 / 16, -0.5, -6 / 16, 6 / 16, -5 / 16, 6 / 16},
 	},
-	on_place          = function(itemstack, placer, pointed_thing)
+
+	on_place = function(itemstack, placer, pointed_thing)
 		-- place a random grass node
-		local stack = ItemStack("default:grass_" .. math.random(1, 5))
-		local ret   = minetest.item_place(stack, placer, pointed_thing)
-		return ItemStack("default:grass_1 " .. itemstack:get_count() - (1 - ret:get_count()))
+		local stack = ItemStack("default:grass_" .. math.random(1,5))
+		local ret = minetest.item_place(stack, placer, pointed_thing)
+		return ItemStack("default:grass_1 " ..
+			itemstack:get_count() - (1 - ret:get_count()))
 	end,
 })
-minetest.register_node("default:grass_2", {
-	description       = S("Grass"),
-	drawtype          = "plantlike",
-	tiles             = { "default_grass_2.png" },
-	inventory_image   = "default_grass_2.png",
-	wield_image       = "default_grass_2.png",
-	paramtype         = "light",
-	walkable          = false,
-	buildable_to      = true,
-	is_ground_content = true,
-	drop              = "default:grass_1",
-	groups            = {
-		snappy                    = 3,
-		flammable                 = 3,
-		flora                     = 1,
-		attached_node             = 1,
-		not_in_creative_inventory = 1,
-		grass                     = 1
-	},
-	sounds            = default.node_sound_leaves_defaults(),
-	selection_box     = {
-		type  = "fixed",
-		fixed = { -0.5, -0.5, -0.5, 0.5, -5 / 16, 0.5 },
-	},
-})
-minetest.register_node("default:grass_3", {
-	description       = S("Grass"),
-	drawtype          = "plantlike",
-	tiles             = { "default_grass_3.png" },
-	inventory_image   = "default_grass_3.png",
-	wield_image       = "default_grass_3.png",
-	paramtype         = "light",
-	walkable          = false,
-	buildable_to      = true,
-	is_ground_content = true,
-	drop              = "default:grass_1",
-	groups            = {
-		snappy                    = 3,
-		flammable                 = 3,
-		flora                     = 1,
-		attached_node             = 1,
-		not_in_creative_inventory = 1,
-		grass                     = 1
-	},
-	sounds            = default.node_sound_leaves_defaults(),
-	selection_box     = {
-		type  = "fixed",
-		fixed = { -0.5, -0.5, -0.5, 0.5, -5 / 16, 0.5 },
-	},
-})
-minetest.register_node("default:grass_4", {
-	description       = S("Grass"),
-	drawtype          = "plantlike",
-	tiles             = { "default_grass_4.png" },
-	inventory_image   = "default_grass_4.png",
-	wield_image       = "default_grass_4.png",
-	paramtype         = "light",
-	walkable          = false,
-	buildable_to      = true,
-	is_ground_content = true,
-	drop              = "default:grass_1",
-	groups            = {
-		snappy                    = 3,
-		flammable                 = 3,
-		flora                     = 1,
-		attached_node             = 1,
-		not_in_creative_inventory = 1,
-		grass                     = 1 },
-	sounds            = default.node_sound_leaves_defaults(),
-	selection_box     = {
-		type  = "fixed",
-		fixed = { -0.5, -0.5, -0.5, 0.5, -5 / 16, 0.5 },
-	},
-})
-minetest.register_node("default:grass_5", {
-	description       = S("Grass"),
-	drawtype          = "plantlike",
-	tiles             = { "default_grass_5.png" },
-	inventory_image   = "default_grass_5.png",
-	wield_image       = "default_grass_5.png",
-	paramtype         = "light",
-	walkable          = false,
-	buildable_to      = true,
-	is_ground_content = true,
-	drop              = "default:grass_1",
-	groups            = {
-		snappy                    = 3,
-		flammable                 = 3,
-		flora                     = 1,
-		attached_node             = 1,
-		not_in_creative_inventory = 1,
-		grass                     = 1
-	},
-	sounds            = default.node_sound_leaves_defaults(),
-	selection_box     = {
-		type  = "fixed",
-		fixed = { -0.5, -0.5, -0.5, 0.5, -5 / 16, 0.5 },
-	},
-})
+
+for i = 2, 5 do
+	minetest.register_node("default:grass_" .. i, {
+		description = S("Grass"),
+		drawtype = "plantlike",
+		waving = 1,
+		tiles = {"default_grass_" .. i .. ".png"},
+		inventory_image = "default_grass_" .. i .. ".png",
+		wield_image = "default_grass_" .. i .. ".png",
+		paramtype = "light",
+		sunlight_propagates = true,
+		walkable = false,
+		buildable_to = true,
+		drop = "default:grass_1",
+		groups = {snappy = 3, flora = 1, attached_node = 1,
+			not_in_creative_inventory = 1, grass = 1,
+			normal_grass = 1, flammable = 1},
+		sounds = default.node_sound_leaves_defaults(),
+		selection_box = {
+			type = "fixed",
+			fixed = {-6 / 16, -0.5, -6 / 16, 6 / 16, -3 / 16, 6 / 16},
+		},
+	})
+end
+
 
 minetest.register_node("default:dry_grass_1", {
 	description = S("Savanna Grass"),
@@ -1492,7 +1525,7 @@ minetest.register_node("default:dry_grass_1", {
 	walkable = false,
 	buildable_to = true,
 	groups = {snappy = 3, flammable = 3, flora = 1,
-			  attached_node = 1, grass = 1, dry_grass = 1},
+		attached_node = 1, grass = 1, dry_grass = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
 		type = "fixed",
@@ -1521,7 +1554,7 @@ for i = 2, 5 do
 		walkable = false,
 		buildable_to = true,
 		groups = {snappy = 3, flammable = 3, flora = 1, attached_node = 1,
-				  not_in_creative_inventory = 1, grass = 1, dry_grass = 1},
+			not_in_creative_inventory = 1, grass = 1, dry_grass = 1},
 		drop = "default:dry_grass_1",
 		sounds = default.node_sound_leaves_defaults(),
 		selection_box = {
@@ -1544,7 +1577,7 @@ minetest.register_node("default:fern_1", {
 	walkable = false,
 	buildable_to = true,
 	groups = {snappy = 3, flammable = 3, flora = 1, grass = 1,
-			  fern = 1, attached_node = 1},
+		fern = 1, attached_node = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
 		type = "fixed",
@@ -1574,7 +1607,7 @@ for i = 2, 3 do
 		walkable = false,
 		buildable_to = true,
 		groups = {snappy = 3, flammable = 3, flora = 1, attached_node = 1,
-				  grass = 1, fern = 1, not_in_creative_inventory = 1},
+			grass = 1, fern = 1, not_in_creative_inventory = 1},
 		drop = "default:fern_1",
 		sounds = default.node_sound_leaves_defaults(),
 		selection_box = {
@@ -1597,7 +1630,7 @@ minetest.register_node("default:marram_grass_1", {
 	walkable = false,
 	buildable_to = true,
 	groups = {snappy = 3, flammable = 3, flora = 1, grass = 1, marram_grass = 1,
-			  attached_node = 1},
+		attached_node = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
 		type = "fixed",
@@ -1626,7 +1659,7 @@ for i = 2, 3 do
 		walkable = false,
 		buildable_to = true,
 		groups = {snappy = 3, flammable = 3, flora = 1, attached_node = 1,
-				  grass = 1, marram_grass = 1, not_in_creative_inventory = 1},
+			grass = 1, marram_grass = 1, not_in_creative_inventory = 1},
 		drop = "default:marram_grass_1",
 		sounds = default.node_sound_leaves_defaults(),
 		selection_box = {
@@ -1636,57 +1669,1179 @@ for i = 2, 3 do
 	})
 end
 
-minetest.register_node("default:ice", {
-	description       = S("Ice"),
-	tiles             = { "default_ice.png" },
-	is_ground_content = true,
-	paramtype         = "light",
-	freezemelt        = "default:water_source",
-	groups            = { cracky = 3, melts = 1 },
-	sounds            = default.node_sound_glass_defaults(),
+
+minetest.register_node("default:bush_stem", {
+	description = S("Bush Stem"),
+	drawtype = "plantlike",
+	visual_scale = 1.41,
+	tiles = {"default_bush_stem.png"},
+	inventory_image = "default_bush_stem.png",
+	wield_image = "default_bush_stem.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	groups = {choppy = 2, oddly_breakable_by_hand = 1, flammable = 2},
+	sounds = default.node_sound_wood_defaults(),
+	selection_box = {
+		type = "fixed",
+		fixed = {-7 / 16, -0.5, -7 / 16, 7 / 16, 0.5, 7 / 16},
+	},
 })
 
-minetest.register_node("default:snow", {
-	description       = S("Snow"),
-	tiles             = { "default_snow.png" },
-	inventory_image   = "default_snowball.png",
-	wield_image       = "default_snowball.png",
-	is_ground_content = true,
-	paramtype         = "light",
-	buildable_to      = true,
-	leveled           = 7,
-	drawtype          = "nodebox",
-	freezemelt        = "default:water_flowing",
-	node_box          = {
-		type  = "leveled",
-		fixed = {
-			{ -0.5, -0.5, -0.5, 0.5, -0.5 + 2 / 16, 0.5 },
-		},
+minetest.register_node("default:bush_leaves", {
+	description = S("Bush Leaves"),
+	drawtype = "allfaces_optional",
+	tiles = {"default_leaves_simple.png"},
+	paramtype = "light",
+	groups = {snappy = 3, flammable = 2, leaves = 1},
+	drop = {
+		max_items = 1,
+		items = {
+			{items = {"default:bush_sapling"}, rarity = 5},
+			{items = {"default:bush_leaves"}}
+		}
 	},
-	groups            = { crumbly = 3, falling_node = 1, melts = 1, float = 1 },
-	sounds            = default.node_sound_dirt_defaults({
-		footstep = { name = "default_snow_footstep", gain = 0.25 },
-		dug      = { name = "default_snow_footstep", gain = 0.75 },
-	}),
-	on_construct      = function(pos)
-		pos.y = pos.y - 1
-		if minetest.get_node(pos).name == "default:dirt_with_grass" then
-			minetest.set_node(pos, { name = "default:dirt_with_snow" })
-		end
+	sounds = default.node_sound_leaves_defaults(),
+
+	after_place_node = after_place_leaves,
+})
+
+minetest.register_node("default:bush_sapling", {
+	description = S("Bush Sapling"),
+	drawtype = "plantlike",
+	tiles = {"default_bush_sapling.png"},
+	inventory_image = "default_bush_sapling.png",
+	wield_image = "default_bush_sapling.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	on_timer = grow_sapling,
+	selection_box = {
+		type = "fixed",
+		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 2 / 16, 4 / 16}
+	},
+	groups = {snappy = 2, dig_immediate = 3, flammable = 2,
+		attached_node = 1, sapling = 1},
+	sounds = default.node_sound_leaves_defaults(),
+
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(300, 1500))
+	end,
+
+	on_place = function(itemstack, placer, pointed_thing)
+		itemstack = default.sapling_on_place(itemstack, placer, pointed_thing,
+			"default:bush_sapling",
+			-- minp, maxp to be checked, relative to sapling pos
+			{x = -1, y = 0, z = -1},
+			{x = 1, y = 1, z = 1},
+			-- maximum interval of interior volume check
+			2)
+
+		return itemstack
 	end,
 })
-minetest.register_alias("snow", "default:snow")
 
-minetest.register_node("default:snowblock", {
-	description       = S("Snow Block"),
-	tiles             = { "default_snow.png" },
-	is_ground_content = true,
-	freezemelt        = "default:water_source",
-	groups            = { crumbly = 3, melts = 1 },
-	sounds            = default.node_sound_dirt_defaults({
-		footstep = { name = "default_snow_footstep", gain = 0.25 },
-		dug      = { name = "default_snow_footstep", gain = 0.75 },
+minetest.register_node("default:blueberry_bush_leaves_with_berries", {
+	description = S("Blueberry Bush Leaves with Berries"),
+	drawtype = "allfaces_optional",
+	tiles = {"default_blueberry_bush_leaves.png^default_blueberry_overlay.png"},
+	paramtype = "light",
+	groups = {snappy = 3, flammable = 2, leaves = 1, dig_immediate = 3},
+	drop = "default:blueberries",
+	sounds = default.node_sound_leaves_defaults(),
+	node_dig_prediction = "default:blueberry_bush_leaves",
+
+	after_dig_node = function(pos, oldnode, oldmetadata, digger)
+		minetest.set_node(pos, {name = "default:blueberry_bush_leaves"})
+		minetest.get_node_timer(pos):start(math.random(300, 1500))
+	end,
+})
+
+minetest.register_node("default:blueberry_bush_leaves", {
+	description = S("Blueberry Bush Leaves"),
+	drawtype = "allfaces_optional",
+	tiles = {"default_blueberry_bush_leaves.png"},
+	paramtype = "light",
+	groups = {snappy = 3, flammable = 2, leaves = 1},
+	drop = {
+		max_items = 1,
+		items = {
+			{items = {"default:blueberry_bush_sapling"}, rarity = 5},
+			{items = {"default:blueberry_bush_leaves"}}
+		}
+	},
+	sounds = default.node_sound_leaves_defaults(),
+
+	on_timer = function(pos, elapsed)
+		if minetest.get_node_light(pos) < 11 then
+			minetest.get_node_timer(pos):start(200)
+		else
+			minetest.set_node(pos, {name = "default:blueberry_bush_leaves_with_berries"})
+		end
+	end,
+
+	after_place_node = after_place_leaves,
+})
+
+minetest.register_node("default:blueberry_bush_sapling", {
+	description = S("Blueberry Bush Sapling"),
+	drawtype = "plantlike",
+	tiles = {"default_blueberry_bush_sapling.png"},
+	inventory_image = "default_blueberry_bush_sapling.png",
+	wield_image = "default_blueberry_bush_sapling.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	on_timer = grow_sapling,
+	selection_box = {
+		type = "fixed",
+		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 2 / 16, 4 / 16}
+	},
+	groups = {snappy = 2, dig_immediate = 3, flammable = 2,
+		attached_node = 1, sapling = 1},
+	sounds = default.node_sound_leaves_defaults(),
+
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(300, 1500))
+	end,
+
+	on_place = function(itemstack, placer, pointed_thing)
+		itemstack = default.sapling_on_place(itemstack, placer, pointed_thing,
+			"default:blueberry_bush_sapling",
+			-- minp, maxp to be checked, relative to sapling pos
+			{x = -1, y = 0, z = -1},
+			{x = 1, y = 1, z = 1},
+			-- maximum interval of interior volume check
+			2)
+
+		return itemstack
+	end,
+})
+
+minetest.register_node("default:acacia_bush_stem", {
+	description = S("Acacia Bush Stem"),
+	drawtype = "plantlike",
+	visual_scale = 1.41,
+	tiles = {"default_acacia_bush_stem.png"},
+	inventory_image = "default_acacia_bush_stem.png",
+	wield_image = "default_acacia_bush_stem.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	groups = {choppy = 2, oddly_breakable_by_hand = 1, flammable = 2},
+	sounds = default.node_sound_wood_defaults(),
+	selection_box = {
+		type = "fixed",
+		fixed = {-7 / 16, -0.5, -7 / 16, 7 / 16, 0.5, 7 / 16},
+	},
+})
+
+minetest.register_node("default:acacia_bush_leaves", {
+	description = S("Acacia Bush Leaves"),
+	drawtype = "allfaces_optional",
+	tiles = {"default_acacia_leaves_simple.png"},
+	paramtype = "light",
+	groups = {snappy = 3, flammable = 2, leaves = 1},
+	drop = {
+		max_items = 1,
+		items = {
+			{items = {"default:acacia_bush_sapling"}, rarity = 5},
+			{items = {"default:acacia_bush_leaves"}}
+		}
+	},
+	sounds = default.node_sound_leaves_defaults(),
+
+	after_place_node = after_place_leaves,
+})
+
+minetest.register_node("default:acacia_bush_sapling", {
+	description = S("Acacia Bush Sapling"),
+	drawtype = "plantlike",
+	tiles = {"default_acacia_bush_sapling.png"},
+	inventory_image = "default_acacia_bush_sapling.png",
+	wield_image = "default_acacia_bush_sapling.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	on_timer = grow_sapling,
+	selection_box = {
+		type = "fixed",
+		fixed = {-3 / 16, -0.5, -3 / 16, 3 / 16, 2 / 16, 3 / 16}
+	},
+	groups = {snappy = 2, dig_immediate = 3, flammable = 2,
+		attached_node = 1, sapling = 1},
+	sounds = default.node_sound_leaves_defaults(),
+
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(300, 1500))
+	end,
+
+	on_place = function(itemstack, placer, pointed_thing)
+		itemstack = default.sapling_on_place(itemstack, placer, pointed_thing,
+			"default:acacia_bush_sapling",
+			-- minp, maxp to be checked, relative to sapling pos
+			{x = -1, y = 0, z = -1},
+			{x = 1, y = 1, z = 1},
+			-- maximum interval of interior volume check
+			2)
+
+		return itemstack
+	end,
+})
+
+minetest.register_node("default:pine_bush_stem", {
+	description = S("Pine Bush Stem"),
+	drawtype = "plantlike",
+	visual_scale = 1.41,
+	tiles = {"default_pine_bush_stem.png"},
+	inventory_image = "default_pine_bush_stem.png",
+	wield_image = "default_pine_bush_stem.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	groups = {choppy = 2, oddly_breakable_by_hand = 1, flammable = 2},
+	sounds = default.node_sound_wood_defaults(),
+	selection_box = {
+		type = "fixed",
+		fixed = {-7 / 16, -0.5, -7 / 16, 7 / 16, 0.5, 7 / 16},
+	},
+})
+
+minetest.register_node("default:pine_bush_needles", {
+	description = S("Pine Bush Needles"),
+	drawtype = "allfaces_optional",
+	tiles = {"default_pine_needles.png"},
+	paramtype = "light",
+	groups = {snappy = 3, flammable = 2, leaves = 1},
+	drop = {
+		max_items = 1,
+		items = {
+			{items = {"default:pine_bush_sapling"}, rarity = 5},
+			{items = {"default:pine_bush_needles"}}
+		}
+	},
+	sounds = default.node_sound_leaves_defaults(),
+
+	after_place_node = after_place_leaves,
+})
+
+minetest.register_node("default:pine_bush_sapling", {
+	description = S("Pine Bush Sapling"),
+	drawtype = "plantlike",
+	tiles = {"default_pine_bush_sapling.png"},
+	inventory_image = "default_pine_bush_sapling.png",
+	wield_image = "default_pine_bush_sapling.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	on_timer = grow_sapling,
+	selection_box = {
+		type = "fixed",
+		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 2 / 16, 4 / 16}
+	},
+	groups = {snappy = 2, dig_immediate = 3, flammable = 2,
+		attached_node = 1, sapling = 1},
+	sounds = default.node_sound_leaves_defaults(),
+
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(300, 1500))
+	end,
+
+	on_place = function(itemstack, placer, pointed_thing)
+		itemstack = default.sapling_on_place(itemstack, placer, pointed_thing,
+			"default:pine_bush_sapling",
+			-- minp, maxp to be checked, relative to sapling pos
+			{x = -1, y = 0, z = -1},
+			{x = 1, y = 1, z = 1},
+			-- maximum interval of interior volume check
+			2)
+
+		return itemstack
+	end,
+})
+
+
+minetest.register_node("default:sand_with_kelp", {
+	description = S("Kelp"),
+	drawtype = "plantlike_rooted",
+	waving = 1,
+	tiles = {"default_sand.png"},
+	special_tiles = {{name = "default_kelp.png", tileable_vertical = true}},
+	inventory_image = "default_kelp.png",
+	wield_image = "default_kelp.png",
+	paramtype = "light",
+	paramtype2 = "leveled",
+	groups = {snappy = 3},
+	selection_box = {
+		type = "fixed",
+		fixed = {
+				{-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
+				{-2/16, 0.5, -2/16, 2/16, 3.5, 2/16},
+		},
+	},
+	node_dig_prediction = "default:sand",
+	node_placement_prediction = "",
+	sounds = default.node_sound_sand_defaults({
+		dig = {name = "default_dig_snappy", gain = 0.2},
+		dug = {name = "default_grass_footstep", gain = 0.25},
 	}),
+
+	on_place = function(itemstack, placer, pointed_thing)
+		-- Call on_rightclick if the pointed node defines it
+		if pointed_thing.type == "node" and placer and
+				not placer:get_player_control().sneak then
+			local node_ptu = minetest.get_node(pointed_thing.under)
+			local def_ptu = minetest.registered_nodes[node_ptu.name]
+			if def_ptu and def_ptu.on_rightclick then
+				return def_ptu.on_rightclick(pointed_thing.under, node_ptu, placer,
+					itemstack, pointed_thing)
+			end
+		end
+
+		local pos = pointed_thing.under
+		if minetest.get_node(pos).name ~= "default:sand" then
+			return itemstack
+		end
+
+		local height = math.random(4, 6)
+		local pos_top = {x = pos.x, y = pos.y + height, z = pos.z}
+		local node_top = minetest.get_node(pos_top)
+		local def_top = minetest.registered_nodes[node_top.name]
+		local player_name = placer:get_player_name()
+
+		if def_top and def_top.liquidtype == "source" and
+				minetest.get_item_group(node_top.name, "water") > 0 then
+			if not minetest.is_protected(pos, player_name) and
+					not minetest.is_protected(pos_top, player_name) then
+				minetest.set_node(pos, {name = "default:sand_with_kelp",
+					param2 = height * 16})
+				if not minetest.is_creative_enabled(player_name) then
+					itemstack:take_item()
+				end
+			else
+				minetest.chat_send_player(player_name, "Node is protected")
+				minetest.record_protection_violation(pos, player_name)
+			end
+		end
+
+		return itemstack
+	end,
+
+	after_destruct  = function(pos, oldnode)
+		minetest.set_node(pos, {name = "default:sand"})
+	end
+})
+
+
+--
+-- Corals
+--
+
+local function coral_on_place(itemstack, placer, pointed_thing)
+	if pointed_thing.type ~= "node" or not placer then
+		return itemstack
+	end
+
+	local player_name = placer:get_player_name()
+	local pos_under = pointed_thing.under
+	local pos_above = pointed_thing.above
+	local node_under = minetest.get_node(pos_under)
+	local def_under = minetest.registered_nodes[node_under.name]
+
+	if def_under and def_under.on_rightclick and not placer:get_player_control().sneak then
+		return def_under.on_rightclick(pos_under, node_under,
+				placer, itemstack, pointed_thing) or itemstack
+	end
+
+	if node_under.name ~= "default:coral_skeleton" or
+			minetest.get_node(pos_above).name ~= "default:water_source" then
+		return itemstack
+	end
+
+	if minetest.is_protected(pos_under, player_name) or
+			minetest.is_protected(pos_above, player_name) then
+		minetest.log("action", player_name
+			.. " tried to place " .. itemstack:get_name()
+			.. " at protected position "
+			.. minetest.pos_to_string(pos_under))
+		minetest.record_protection_violation(pos_under, player_name)
+		return itemstack
+	end
+
+	node_under.name = itemstack:get_name()
+	minetest.set_node(pos_under, node_under)
+	if not minetest.is_creative_enabled(player_name) then
+		itemstack:take_item()
+	end
+
+	return itemstack
+end
+
+minetest.register_node("default:coral_green", {
+	description = S("Green Coral"),
+	drawtype = "plantlike_rooted",
+	waving = 1,
+	paramtype = "light",
+	tiles = {"default_coral_skeleton.png"},
+	special_tiles = {{name = "default_coral_green.png", tileable_vertical = true}},
+	inventory_image = "default_coral_green.png",
+	wield_image = "default_coral_green.png",
+	groups = {snappy = 3},
+	selection_box = {
+		type = "fixed",
+		fixed = {
+				{-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
+				{-4/16, 0.5, -4/16, 4/16, 1.5, 4/16},
+		},
+	},
+	node_dig_prediction = "default:coral_skeleton",
+	node_placement_prediction = "",
+	sounds = default.node_sound_stone_defaults({
+		dig = {name = "default_dig_snappy", gain = 0.2},
+		dug = {name = "default_grass_footstep", gain = 0.25},
+	}),
+
+	on_place = coral_on_place,
+
+	after_destruct  = function(pos, oldnode)
+		minetest.set_node(pos, {name = "default:coral_skeleton"})
+	end,
+})
+
+minetest.register_node("default:coral_pink", {
+	description = S("Pink Coral"),
+	drawtype = "plantlike_rooted",
+	waving = 1,
+	paramtype = "light",
+	tiles = {"default_coral_skeleton.png"},
+	special_tiles = {{name = "default_coral_pink.png", tileable_vertical = true}},
+	inventory_image = "default_coral_pink.png",
+	wield_image = "default_coral_pink.png",
+	groups = {snappy = 3},
+	selection_box = {
+		type = "fixed",
+		fixed = {
+				{-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
+				{-4/16, 0.5, -4/16, 4/16, 1.5, 4/16},
+		},
+	},
+	node_dig_prediction = "default:coral_skeleton",
+	node_placement_prediction = "",
+	sounds = default.node_sound_stone_defaults({
+		dig = {name = "default_dig_snappy", gain = 0.2},
+		dug = {name = "default_grass_footstep", gain = 0.25},
+	}),
+
+	on_place = coral_on_place,
+
+	after_destruct  = function(pos, oldnode)
+		minetest.set_node(pos, {name = "default:coral_skeleton"})
+	end,
+})
+
+minetest.register_node("default:coral_cyan", {
+	description = S("Cyan Coral"),
+	drawtype = "plantlike_rooted",
+	waving = 1,
+	paramtype = "light",
+	tiles = {"default_coral_skeleton.png"},
+	special_tiles = {{name = "default_coral_cyan.png", tileable_vertical = true}},
+	inventory_image = "default_coral_cyan.png",
+	wield_image = "default_coral_cyan.png",
+	groups = {snappy = 3},
+	selection_box = {
+		type = "fixed",
+		fixed = {
+				{-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
+				{-4/16, 0.5, -4/16, 4/16, 1.5, 4/16},
+		},
+	},
+	node_dig_prediction = "default:coral_skeleton",
+	node_placement_prediction = "",
+	sounds = default.node_sound_stone_defaults({
+		dig = {name = "default_dig_snappy", gain = 0.2},
+		dug = {name = "default_grass_footstep", gain = 0.25},
+	}),
+
+	on_place = coral_on_place,
+
+	after_destruct  = function(pos, oldnode)
+		minetest.set_node(pos, {name = "default:coral_skeleton"})
+	end,
+})
+
+minetest.register_node("default:coral_brown", {
+	description = S("Brown Coral"),
+	tiles = {"default_coral_brown.png"},
+	groups = {cracky = 3},
+	drop = "default:coral_skeleton",
+	sounds = default.node_sound_stone_defaults(),
+})
+
+minetest.register_node("default:coral_orange", {
+	description = S("Orange Coral"),
+	tiles = {"default_coral_orange.png"},
+	groups = {cracky = 3},
+	drop = "default:coral_skeleton",
+	sounds = default.node_sound_stone_defaults(),
+})
+
+minetest.register_node("default:coral_skeleton", {
+	description = S("Coral Skeleton"),
+	tiles = {"default_coral_skeleton.png"},
+	groups = {cracky = 3},
+	sounds = default.node_sound_stone_defaults(),
+})
+
+
+--
+-- Liquids
+--
+
+minetest.register_node("default:water_source", {
+	description = S("Water Source"),
+	drawtype = "liquid",
+	waving = 3,
+	tiles = {
+		{
+			name = "default_water_source_animated.png",
+			backface_culling = false,
+			animation = {
+				type = "vertical_frames",
+				aspect_w = 16,
+				aspect_h = 16,
+				length = 2.0,
+			},
+		},
+		{
+			name = "default_water_source_animated.png",
+			backface_culling = true,
+			animation = {
+				type = "vertical_frames",
+				aspect_w = 16,
+				aspect_h = 16,
+				length = 2.0,
+			},
+		},
+	},
+	use_texture_alpha = "blend",
+	paramtype = "light",
+	walkable = false,
+	pointable = false,
+	diggable = false,
+	buildable_to = true,
+	is_ground_content = false,
+	drop = "",
+	drowning = 1,
+	liquidtype = "source",
+	liquid_alternative_flowing = "default:water_flowing",
+	liquid_alternative_source = "default:water_source",
+	liquid_viscosity = 1,
+	post_effect_color = {a = 103, r = 30, g = 60, b = 90},
+	groups = {water = 3, liquid = 3, cools_lava = 1},
+	sounds = default.node_sound_water_defaults(),
+})
+
+minetest.register_node("default:water_flowing", {
+	description = S("Flowing Water"),
+	drawtype = "flowingliquid",
+	waving = 3,
+	tiles = {"default_water.png"},
+	special_tiles = {
+		{
+			name = "default_water_flowing_animated.png",
+			backface_culling = false,
+			animation = {
+				type = "vertical_frames",
+				aspect_w = 16,
+				aspect_h = 16,
+				length = 0.5,
+			},
+		},
+		{
+			name = "default_water_flowing_animated.png",
+			backface_culling = true,
+			animation = {
+				type = "vertical_frames",
+				aspect_w = 16,
+				aspect_h = 16,
+				length = 0.5,
+			},
+		},
+	},
+	use_texture_alpha = "blend",
+	paramtype = "light",
+	paramtype2 = "flowingliquid",
+	walkable = false,
+	pointable = false,
+	diggable = false,
+	buildable_to = true,
+	is_ground_content = false,
+	drop = "",
+	drowning = 1,
+	liquidtype = "flowing",
+	liquid_alternative_flowing = "default:water_flowing",
+	liquid_alternative_source = "default:water_source",
+	liquid_viscosity = 1,
+	post_effect_color = {a = 103, r = 30, g = 60, b = 90},
+	groups = {water = 3, liquid = 3, not_in_creative_inventory = 1,
+		cools_lava = 1},
+	sounds = default.node_sound_water_defaults(),
+})
+
+
+minetest.register_node("default:river_water_source", {
+	description = S("River Water Source"),
+	drawtype = "liquid",
+	tiles = {
+		{
+			name = "default_river_water_source_animated.png",
+			backface_culling = false,
+			animation = {
+				type = "vertical_frames",
+				aspect_w = 16,
+				aspect_h = 16,
+				length = 2.0,
+			},
+		},
+		{
+			name = "default_river_water_source_animated.png",
+			backface_culling = true,
+			animation = {
+				type = "vertical_frames",
+				aspect_w = 16,
+				aspect_h = 16,
+				length = 2.0,
+			},
+		},
+	},
+	use_texture_alpha = "blend",
+	paramtype = "light",
+	walkable = false,
+	pointable = false,
+	diggable = false,
+	buildable_to = true,
+	is_ground_content = false,
+	drop = "",
+	drowning = 1,
+	liquidtype = "source",
+	liquid_alternative_flowing = "default:river_water_flowing",
+	liquid_alternative_source = "default:river_water_source",
+	liquid_viscosity = 1,
+	-- Not renewable to avoid horizontal spread of water sources in sloping
+	-- rivers that can cause water to overflow riverbanks and cause floods.
+	-- River water source is instead made renewable by the 'force renew'
+	-- option used in the 'bucket' mod by the river water bucket.
+	liquid_renewable = false,
+	liquid_range = 2,
+	post_effect_color = {a = 103, r = 30, g = 76, b = 90},
+	groups = {water = 3, liquid = 3, cools_lava = 1},
+	sounds = default.node_sound_water_defaults(),
+})
+
+minetest.register_node("default:river_water_flowing", {
+	description = S("Flowing River Water"),
+	drawtype = "flowingliquid",
+	tiles = {"default_river_water.png"},
+	special_tiles = {
+		{
+			name = "default_river_water_flowing_animated.png",
+			backface_culling = false,
+			animation = {
+				type = "vertical_frames",
+				aspect_w = 16,
+				aspect_h = 16,
+				length = 0.5,
+			},
+		},
+		{
+			name = "default_river_water_flowing_animated.png",
+			backface_culling = true,
+			animation = {
+				type = "vertical_frames",
+				aspect_w = 16,
+				aspect_h = 16,
+				length = 0.5,
+			},
+		},
+	},
+	use_texture_alpha = "blend",
+	paramtype = "light",
+	paramtype2 = "flowingliquid",
+	walkable = false,
+	pointable = false,
+	diggable = false,
+	buildable_to = true,
+	is_ground_content = false,
+	drop = "",
+	drowning = 1,
+	liquidtype = "flowing",
+	liquid_alternative_flowing = "default:river_water_flowing",
+	liquid_alternative_source = "default:river_water_source",
+	liquid_viscosity = 1,
+	liquid_renewable = false,
+	liquid_range = 2,
+	post_effect_color = {a = 103, r = 30, g = 76, b = 90},
+	groups = {water = 3, liquid = 3, not_in_creative_inventory = 1,
+		cools_lava = 1},
+	sounds = default.node_sound_water_defaults(),
+})
+
+
+minetest.register_node("default:lava_source", {
+	description = S("Lava Source"),
+	drawtype = "liquid",
+	tiles = {
+		{
+			name = "default_lava_source_animated.png",
+			backface_culling = false,
+			animation = {
+				type = "vertical_frames",
+				aspect_w = 16,
+				aspect_h = 16,
+				length = 3.0,
+			},
+		},
+		{
+			name = "default_lava_source_animated.png",
+			backface_culling = true,
+			animation = {
+				type = "vertical_frames",
+				aspect_w = 16,
+				aspect_h = 16,
+				length = 3.0,
+			},
+		},
+	},
+	paramtype = "light",
+	light_source = default.LIGHT_MAX - 1,
+	walkable = false,
+	pointable = false,
+	diggable = false,
+	buildable_to = true,
+	is_ground_content = false,
+	drop = "",
+	drowning = 1,
+	liquidtype = "source",
+	liquid_alternative_flowing = "default:lava_flowing",
+	liquid_alternative_source = "default:lava_source",
+	liquid_viscosity = 7,
+	liquid_renewable = false,
+	damage_per_second = 4 * 2,
+	post_effect_color = {a = 191, r = 255, g = 64, b = 0},
+	groups = {lava = 3, liquid = 2, igniter = 1},
+})
+
+minetest.register_node("default:lava_flowing", {
+	description = S("Flowing Lava"),
+	drawtype = "flowingliquid",
+	tiles = {"default_lava.png"},
+	special_tiles = {
+		{
+			name = "default_lava_flowing_animated.png",
+			backface_culling = false,
+			animation = {
+				type = "vertical_frames",
+				aspect_w = 16,
+				aspect_h = 16,
+				length = 3.3,
+			},
+		},
+		{
+			name = "default_lava_flowing_animated.png",
+			backface_culling = true,
+			animation = {
+				type = "vertical_frames",
+				aspect_w = 16,
+				aspect_h = 16,
+				length = 3.3,
+			},
+		},
+	},
+	paramtype = "light",
+	paramtype2 = "flowingliquid",
+	light_source = default.LIGHT_MAX - 1,
+	walkable = false,
+	pointable = false,
+	diggable = false,
+	buildable_to = true,
+	is_ground_content = false,
+	drop = "",
+	drowning = 1,
+	liquidtype = "flowing",
+	liquid_alternative_flowing = "default:lava_flowing",
+	liquid_alternative_source = "default:lava_source",
+	liquid_viscosity = 7,
+	liquid_renewable = false,
+	damage_per_second = 4 * 2,
+	post_effect_color = {a = 191, r = 255, g = 64, b = 0},
+	groups = {lava = 3, liquid = 2, igniter = 1,
+		not_in_creative_inventory = 1},
+})
+
+--
+-- Tools / "Advanced" crafting / Non-"natural"
+--
+
+local bookshelf_formspec =
+	"size[8,7;]" ..
+	"list[context;books;0,0.3;8,2;]" ..
+	"list[current_player;main;0,2.85;8,1;]" ..
+	"list[current_player;main;0,4.08;8,3;8]" ..
+	"listring[context;books]" ..
+	"listring[current_player;main]" ..
+	default.get_hotbar_bg(0,2.85)
+
+local function update_bookshelf(pos)
+	local meta = minetest.get_meta(pos)
+	local inv = meta:get_inventory()
+	local invlist = inv:get_list("books")
+
+	local formspec = bookshelf_formspec
+	-- Inventory slots overlay
+	local bx, by = 0, 0.3
+	local n_written, n_empty = 0, 0
+	for i = 1, 16 do
+		if i == 9 then
+			bx = 0
+			by = by + 1
+		end
+		local stack = invlist[i]
+		if stack:is_empty() then
+			formspec = formspec ..
+				"image[" .. bx .. "," .. by .. ";1,1;default_bookshelf_slot.png]"
+		else
+			local metatable = stack:get_meta():to_table() or {}
+			if metatable.fields and metatable.fields.text then
+				n_written = n_written + stack:get_count()
+			else
+				n_empty = n_empty + stack:get_count()
+			end
+		end
+		bx = bx + 1
+	end
+	meta:set_string("formspec", formspec)
+	if n_written + n_empty == 0 then
+		meta:set_string("infotext", S("Empty Bookshelf"))
+	else
+		meta:set_string("infotext", S("Bookshelf (@1 written, @2 empty books)", n_written, n_empty))
+	end
+end
+
+minetest.register_node("default:bookshelf", {
+	description = S("Bookshelf"),
+	tiles = {"default_wood.png", "default_wood.png", "default_wood.png",
+		"default_wood.png", "default_bookshelf.png", "default_bookshelf.png"},
+	paramtype2 = "facedir",
+	is_ground_content = false,
+	groups = {choppy = 3, oddly_breakable_by_hand = 2, flammable = 3},
+	sounds = default.node_sound_wood_defaults(),
+
+	on_construct = function(pos)
+		local meta = minetest.get_meta(pos)
+		local inv = meta:get_inventory()
+		inv:set_size("books", 8 * 2)
+		update_bookshelf(pos)
+	end,
+	can_dig = function(pos,player)
+		local inv = minetest.get_meta(pos):get_inventory()
+		return inv:is_empty("books")
+	end,
+	allow_metadata_inventory_put = function(pos, listname, index, stack)
+		if minetest.get_item_group(stack:get_name(), "book") ~= 0 then
+			return stack:get_count()
+		end
+		return 0
+	end,
+	on_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
+		minetest.log("action", player:get_player_name() ..
+			" moves stuff in bookshelf at " .. minetest.pos_to_string(pos))
+		update_bookshelf(pos)
+	end,
+	on_metadata_inventory_put = function(pos, listname, index, stack, player)
+		minetest.log("action", player:get_player_name() ..
+			" puts stuff to bookshelf at " .. minetest.pos_to_string(pos))
+		update_bookshelf(pos)
+	end,
+	on_metadata_inventory_take = function(pos, listname, index, stack, player)
+		minetest.log("action", player:get_player_name() ..
+			" takes stuff from bookshelf at " .. minetest.pos_to_string(pos))
+		update_bookshelf(pos)
+	end,
+	on_blast = function(pos)
+		local drops = {}
+		default.get_inventory_drops(pos, "books", drops)
+		drops[#drops+1] = "default:bookshelf"
+		minetest.remove_node(pos)
+		return drops
+	end,
+})
+
+local function register_sign(material, desc, def)
+	minetest.register_node("default:sign_wall_" .. material, {
+		description = desc,
+		drawtype = "nodebox",
+		tiles = {"default_sign_wall_" .. material .. ".png"},
+		inventory_image = "default_sign_" .. material .. ".png",
+		wield_image = "default_sign_" .. material .. ".png",
+		paramtype = "light",
+		paramtype2 = "wallmounted",
+		sunlight_propagates = true,
+		is_ground_content = false,
+		walkable = false,
+		use_texture_alpha = "opaque",
+		node_box = {
+			type = "wallmounted",
+			wall_top    = {-0.4375, 0.4375, -0.3125, 0.4375, 0.5, 0.3125},
+			wall_bottom = {-0.4375, -0.5, -0.3125, 0.4375, -0.4375, 0.3125},
+			wall_side   = {-0.5, -0.3125, -0.4375, -0.4375, 0.3125, 0.4375},
+		},
+		groups = def.groups,
+		legacy_wallmounted = true,
+		sounds = def.sounds,
+
+		on_construct = function(pos)
+			local meta = minetest.get_meta(pos)
+			meta:set_string("formspec", "field[text;;${text}]")
+		end,
+		on_receive_fields = function(pos, formname, fields, sender)
+			local player_name = sender:get_player_name()
+			if minetest.is_protected(pos, player_name) then
+				minetest.record_protection_violation(pos, player_name)
+				return
+			end
+			local text = fields.text
+			if not text then
+				return
+			end
+			if string.len(text) > 512 then
+				minetest.chat_send_player(player_name, S("Text too long"))
+				return
+			end
+			minetest.log("action", player_name .. " wrote \"" .. text ..
+				"\" to the sign at " .. minetest.pos_to_string(pos))
+			local meta = minetest.get_meta(pos)
+			meta:set_string("text", text)
+
+			if #text > 0 then
+				meta:set_string("infotext", S('"@1"', text))
+			else
+				meta:set_string("infotext", '')
+			end
+		end,
+	})
+end
+
+register_sign("wood", S("Wooden Sign"), {
+	sounds = default.node_sound_wood_defaults(),
+	groups = {choppy = 2, attached_node = 1, flammable = 2, oddly_breakable_by_hand = 3}
+})
+
+register_sign("steel", S("Steel Sign"), {
+	sounds = default.node_sound_metal_defaults(),
+	groups = {cracky = 2, attached_node = 1}
+})
+
+minetest.register_node("default:ladder_wood", {
+	description = S("Wooden Ladder"),
+	drawtype = "signlike",
+	tiles = {"default_ladder_wood.png"},
+	inventory_image = "default_ladder_wood.png",
+	wield_image = "default_ladder_wood.png",
+	paramtype = "light",
+	paramtype2 = "wallmounted",
+	sunlight_propagates = true,
+	walkable = false,
+	climbable = true,
+	is_ground_content = false,
+	selection_box = {
+		type = "wallmounted",
+		--wall_top = = <default>
+		--wall_bottom = = <default>
+		--wall_side = = <default>
+	},
+	groups = {choppy = 2, oddly_breakable_by_hand = 3, flammable = 2},
+	legacy_wallmounted = true,
+	sounds = default.node_sound_wood_defaults(),
+})
+
+minetest.register_node("default:ladder_steel", {
+	description = S("Steel Ladder"),
+	drawtype = "signlike",
+	tiles = {"default_ladder_steel.png"},
+	inventory_image = "default_ladder_steel.png",
+	wield_image = "default_ladder_steel.png",
+	paramtype = "light",
+	paramtype2 = "wallmounted",
+	sunlight_propagates = true,
+	walkable = false,
+	climbable = true,
+	is_ground_content = false,
+	selection_box = {
+		type = "wallmounted",
+		--wall_top = = <default>
+		--wall_bottom = = <default>
+		--wall_side = = <default>
+	},
+	groups = {cracky = 2},
+	sounds = default.node_sound_metal_defaults(),
+})
+
+default.register_fence("default:fence_wood", {
+	description = S("Apple Wood Fence"),
+	texture = "default_fence_wood.png",
+	inventory_image = "default_fence_overlay.png^default_wood.png^" ..
+				"default_fence_overlay.png^[makealpha:255,126,126",
+	wield_image = "default_fence_overlay.png^default_wood.png^" ..
+				"default_fence_overlay.png^[makealpha:255,126,126",
+	material = "default:wood",
+	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
+	sounds = default.node_sound_wood_defaults()
+})
+
+default.register_fence("default:fence_acacia_wood", {
+	description = S("Acacia Wood Fence"),
+	texture = "default_fence_acacia_wood.png",
+	inventory_image = "default_fence_overlay.png^default_acacia_wood.png^" ..
+				"default_fence_overlay.png^[makealpha:255,126,126",
+	wield_image = "default_fence_overlay.png^default_acacia_wood.png^" ..
+				"default_fence_overlay.png^[makealpha:255,126,126",
+	material = "default:acacia_wood",
+	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
+	sounds = default.node_sound_wood_defaults()
+})
+
+default.register_fence("default:fence_junglewood", {
+	description = S("Jungle Wood Fence"),
+	texture = "default_fence_junglewood.png",
+	inventory_image = "default_fence_overlay.png^default_junglewood.png^" ..
+				"default_fence_overlay.png^[makealpha:255,126,126",
+	wield_image = "default_fence_overlay.png^default_junglewood.png^" ..
+				"default_fence_overlay.png^[makealpha:255,126,126",
+	material = "default:junglewood",
+	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
+	sounds = default.node_sound_wood_defaults()
+})
+
+default.register_fence("default:fence_pine_wood", {
+	description = S("Pine Wood Fence"),
+	texture = "default_fence_pine_wood.png",
+	inventory_image = "default_fence_overlay.png^default_pine_wood.png^" ..
+				"default_fence_overlay.png^[makealpha:255,126,126",
+	wield_image = "default_fence_overlay.png^default_pine_wood.png^" ..
+				"default_fence_overlay.png^[makealpha:255,126,126",
+	material = "default:pine_wood",
+	groups = {choppy = 3, oddly_breakable_by_hand = 2, flammable = 3},
+	sounds = default.node_sound_wood_defaults()
+})
+
+default.register_fence("default:fence_aspen_wood", {
+	description = S("Aspen Wood Fence"),
+	texture = "default_fence_aspen_wood.png",
+	inventory_image = "default_fence_overlay.png^default_aspen_wood.png^" ..
+				"default_fence_overlay.png^[makealpha:255,126,126",
+	wield_image = "default_fence_overlay.png^default_aspen_wood.png^" ..
+				"default_fence_overlay.png^[makealpha:255,126,126",
+	material = "default:aspen_wood",
+	groups = {choppy = 3, oddly_breakable_by_hand = 2, flammable = 3},
+	sounds = default.node_sound_wood_defaults()
+})
+
+default.register_fence_rail("default:fence_rail_wood", {
+	description = S("Apple Wood Fence Rail"),
+	texture = "default_fence_rail_wood.png",
+	inventory_image = "default_fence_rail_overlay.png^default_wood.png^" ..
+				"default_fence_rail_overlay.png^[makealpha:255,126,126",
+	wield_image = "default_fence_rail_overlay.png^default_wood.png^" ..
+				"default_fence_rail_overlay.png^[makealpha:255,126,126",
+	material = "default:wood",
+	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
+	sounds = default.node_sound_wood_defaults()
+})
+
+default.register_fence_rail("default:fence_rail_acacia_wood", {
+	description = S("Acacia Wood Fence Rail"),
+	texture = "default_fence_rail_acacia_wood.png",
+	inventory_image = "default_fence_rail_overlay.png^default_acacia_wood.png^" ..
+				"default_fence_rail_overlay.png^[makealpha:255,126,126",
+	wield_image = "default_fence_rail_overlay.png^default_acacia_wood.png^" ..
+				"default_fence_rail_overlay.png^[makealpha:255,126,126",
+	material = "default:acacia_wood",
+	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
+	sounds = default.node_sound_wood_defaults()
+})
+
+default.register_fence_rail("default:fence_rail_junglewood", {
+	description = S("Jungle Wood Fence Rail"),
+	texture = "default_fence_rail_junglewood.png",
+	inventory_image = "default_fence_rail_overlay.png^default_junglewood.png^" ..
+				"default_fence_rail_overlay.png^[makealpha:255,126,126",
+	wield_image = "default_fence_rail_overlay.png^default_junglewood.png^" ..
+				"default_fence_rail_overlay.png^[makealpha:255,126,126",
+	material = "default:junglewood",
+	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
+	sounds = default.node_sound_wood_defaults()
+})
+
+default.register_fence_rail("default:fence_rail_pine_wood", {
+	description = S("Pine Wood Fence Rail"),
+	texture = "default_fence_rail_pine_wood.png",
+	inventory_image = "default_fence_rail_overlay.png^default_pine_wood.png^" ..
+				"default_fence_rail_overlay.png^[makealpha:255,126,126",
+	wield_image = "default_fence_rail_overlay.png^default_pine_wood.png^" ..
+				"default_fence_rail_overlay.png^[makealpha:255,126,126",
+	material = "default:pine_wood",
+	groups = {choppy = 3, oddly_breakable_by_hand = 2, flammable = 3},
+	sounds = default.node_sound_wood_defaults()
+})
+
+default.register_fence_rail("default:fence_rail_aspen_wood", {
+	description = S("Aspen Wood Fence Rail"),
+	texture = "default_fence_rail_aspen_wood.png",
+	inventory_image = "default_fence_rail_overlay.png^default_aspen_wood.png^" ..
+				"default_fence_rail_overlay.png^[makealpha:255,126,126",
+	wield_image = "default_fence_rail_overlay.png^default_aspen_wood.png^" ..
+				"default_fence_rail_overlay.png^[makealpha:255,126,126",
+	material = "default:aspen_wood",
+	groups = {choppy = 3, oddly_breakable_by_hand = 2, flammable = 2},
+	sounds = default.node_sound_wood_defaults()
+})
+
+minetest.register_node("default:glass", {
+	description = S("Glass"),
+	drawtype = "glasslike_framed_optional",
+	tiles = {"default_glass.png", "default_glass_detail.png"},
+	use_texture_alpha = "clip", -- only needed for stairs API
+	paramtype = "light",
+	paramtype2 = "glasslikeliquidlevel",
+	sunlight_propagates = true,
+	is_ground_content = false,
+	groups = {cracky = 3, oddly_breakable_by_hand = 3},
+	sounds = default.node_sound_glass_defaults(),
+})
+
+minetest.register_node("default:obsidian_glass", {
+	description = S("Obsidian Glass"),
+	drawtype = "glasslike_framed_optional",
+	tiles = {"default_obsidian_glass.png", "default_obsidian_glass_detail.png"},
+	use_texture_alpha = "clip", -- only needed for stairs API
+	paramtype = "light",
+	paramtype2 = "glasslikeliquidlevel",
+	is_ground_content = false,
+	sunlight_propagates = true,
+	sounds = default.node_sound_glass_defaults(),
+	groups = {cracky = 3},
+})
+
+
+minetest.register_node("default:brick", {
+	description = S("Brick Block"),
+	paramtype2 = "facedir",
+	place_param2 = 0,
+	tiles = {
+		"default_brick.png^[transformFX",
+		"default_brick.png",
+	},
+	is_ground_content = false,
+	groups = {cracky = 3},
+	sounds = default.node_sound_stone_defaults(),
 })
 
 
@@ -1700,4 +2855,112 @@ minetest.register_node("default:meselamp", {
 	groups = {cracky = 3, oddly_breakable_by_hand = 3},
 	sounds = default.node_sound_glass_defaults(),
 	light_source = default.LIGHT_MAX,
+})
+
+default.register_mesepost("default:mese_post_light", {
+	description = S("Apple Wood Mese Post Light"),
+	texture = "default_fence_wood.png",
+	material = "default:wood",
+})
+
+default.register_mesepost("default:mese_post_light_acacia_wood", {
+	description = S("Acacia Wood Mese Post Light"),
+	texture = "default_fence_acacia_wood.png",
+	material = "default:acacia_wood",
+})
+
+default.register_mesepost("default:mese_post_light_junglewood", {
+	description = S("Jungle Wood Mese Post Light"),
+	texture = "default_fence_junglewood.png",
+	material = "default:junglewood",
+})
+
+default.register_mesepost("default:mese_post_light_pine_wood", {
+	description = S("Pine Wood Mese Post Light"),
+	texture = "default_fence_pine_wood.png",
+	material = "default:pine_wood",
+})
+
+default.register_mesepost("default:mese_post_light_aspen_wood", {
+	description = S("Aspen Wood Mese Post Light"),
+	texture = "default_fence_aspen_wood.png",
+	material = "default:aspen_wood",
+})
+
+--
+-- Misc
+--
+
+minetest.register_node("default:cloud", {
+	description = S("Cloud"),
+	tiles = {"default_cloud.png"},
+	is_ground_content = false,
+	sounds = default.node_sound_defaults(),
+	groups = {not_in_creative_inventory = 1},
+})
+
+--
+-- register trees for leafdecay
+--
+
+if minetest.get_mapgen_setting("mg_name") == "v6" then
+	default.register_leafdecay({
+		trunks = {"default:tree"},
+		leaves = {"default:apple", "default:leaves"},
+		radius = 2,
+	})
+
+	default.register_leafdecay({
+		trunks = {"default:jungletree"},
+		leaves = {"default:jungleleaves"},
+		radius = 3,
+	})
+else
+	default.register_leafdecay({
+		trunks = {"default:tree"},
+		leaves = {"default:apple", "default:leaves"},
+		radius = 3,
+	})
+
+	default.register_leafdecay({
+		trunks = {"default:jungletree"},
+		leaves = {"default:jungleleaves"},
+		radius = 2,
+	})
+end
+
+default.register_leafdecay({
+	trunks = {"default:pine_tree"},
+	leaves = {"default:pine_needles"},
+	radius = 3,
+})
+
+default.register_leafdecay({
+	trunks = {"default:acacia_tree"},
+	leaves = {"default:acacia_leaves"},
+	radius = 2,
+})
+
+default.register_leafdecay({
+	trunks = {"default:aspen_tree"},
+	leaves = {"default:aspen_leaves"},
+	radius = 3,
+})
+
+default.register_leafdecay({
+	trunks = {"default:bush_stem"},
+	leaves = {"default:bush_leaves"},
+	radius = 1,
+})
+
+default.register_leafdecay({
+	trunks = {"default:acacia_bush_stem"},
+	leaves = {"default:acacia_bush_leaves"},
+	radius = 1,
+})
+
+default.register_leafdecay({
+	trunks = {"default:pine_bush_stem"},
+	leaves = {"default:pine_bush_needles"},
+	radius = 1,
 })

--- a/mods/_minetest_game/default/trees.lua
+++ b/mods/_minetest_game/default/trees.lua
@@ -1,63 +1,117 @@
+-- default/trees.lua
+
+-- support for MT game translation.
+local S = default.get_translator
+
+local random = math.random
+
 --
 -- Grow trees from saplings
 --
 
-local random = math.random
+-- 'can grow' function
+
+function default.can_grow(pos)
+	local node_under = minetest.get_node_or_nil({x = pos.x, y = pos.y - 1, z = pos.z})
+	if not node_under then
+		return false
+	end
+	if minetest.get_item_group(node_under.name, "soil") == 0 then
+		return false
+	end
+	local light_level = minetest.get_node_light(pos)
+	if not light_level or light_level < 13 then
+		return false
+	end
+	return true
+end
 
 
--- Sapling ABM
+-- 'is snow nearby' function
 
-minetest.register_abm({
-	nodenames = {
-		"default:sapling", "default:junglesapling",
-		"default:pine_sapling", "default:acacia_sapling",
-		"default:aspen_sapling"
-	},
-	interval  = 10, -- 10
-	chance    = 50, -- 50
-	action    = function(pos, node)
-		if not default.can_grow(pos) then
-			return
+local function is_snow_nearby(pos)
+	return minetest.find_node_near(pos, 1, {"group:snowy"})
+end
+
+
+-- Grow sapling
+
+function default.grow_sapling(pos)
+	if not default.can_grow(pos) then
+		-- try again 5 min later
+		minetest.get_node_timer(pos):start(300)
+		return
+	end
+
+	local mg_name = minetest.get_mapgen_setting("mg_name")
+	local node = minetest.get_node(pos)
+	if node.name == "default:sapling" then
+		minetest.log("action", "A sapling grows into a tree at "..
+			minetest.pos_to_string(pos))
+		if mg_name == "v6" then
+			default.grow_tree(pos, random(1, 4) == 1)
+		else
+			default.grow_new_apple_tree(pos)
 		end
-
-		local mapgen = minetest.get_mapgen_params().mgname
-		print(mapgen)
-		if node.name == "default:sapling" then
-			minetest.log("action", "A sapling grows into a tree at " ..
-				minetest.pos_to_string(pos))
-			if mapgen == "v6" then
-				default.grow_tree(pos, random(1, 4) == 1)
-			else
-				default.grow_new_apple_tree(pos)
-			end
-		elseif node.name == "default:junglesapling" then
-			minetest.log("action", "A jungle sapling grows into a tree at " ..
-				minetest.pos_to_string(pos))
-			if mapgen == "v6" then
-				default.grow_jungle_tree(pos)
-			else
-				default.grow_new_jungle_tree(pos)
-			end
-		elseif node.name == "default:pine_sapling" then
-			minetest.log("action", "A pine sapling grows into a tree at " ..
-				minetest.pos_to_string(pos))
-			if mapgen == "v6" then
-				default.grow_pine_tree(pos)
-			else
-				default.grow_new_pine_tree(pos)
-			end
-		elseif node.name == "default:acacia_sapling" then
-			minetest.log("action", "An acacia sapling grows into a tree at " ..
-				minetest.pos_to_string(pos))
-			default.grow_new_acacia_tree(pos)
-		elseif node.name == "default:aspen_sapling" then
-			minetest.log("action", "An aspen sapling grows into a tree at " ..
-				minetest.pos_to_string(pos))
-			default.grow_new_aspen_tree(pos)
+	elseif node.name == "default:junglesapling" then
+		minetest.log("action", "A jungle sapling grows into a tree at "..
+			minetest.pos_to_string(pos))
+		if mg_name == "v6" then
+			default.grow_jungle_tree(pos)
+		else
+			default.grow_new_jungle_tree(pos)
 		end
+	elseif node.name == "default:pine_sapling" then
+		minetest.log("action", "A pine sapling grows into a tree at "..
+			minetest.pos_to_string(pos))
+		local snow = is_snow_nearby(pos)
+		if mg_name == "v6" then
+			default.grow_pine_tree(pos, snow)
+		elseif snow then
+			default.grow_new_snowy_pine_tree(pos)
+		else
+			default.grow_new_pine_tree(pos)
+		end
+	elseif node.name == "default:acacia_sapling" then
+		minetest.log("action", "An acacia sapling grows into a tree at "..
+			minetest.pos_to_string(pos))
+		default.grow_new_acacia_tree(pos)
+	elseif node.name == "default:aspen_sapling" then
+		minetest.log("action", "An aspen sapling grows into a tree at "..
+			minetest.pos_to_string(pos))
+		default.grow_new_aspen_tree(pos)
+	elseif node.name == "default:bush_sapling" then
+		minetest.log("action", "A bush sapling grows into a bush at "..
+			minetest.pos_to_string(pos))
+		default.grow_bush(pos)
+	elseif node.name == "default:blueberry_bush_sapling" then
+		minetest.log("action", "A blueberry bush sapling grows into a bush at "..
+			minetest.pos_to_string(pos))
+		default.grow_blueberry_bush(pos)
+	elseif node.name == "default:acacia_bush_sapling" then
+		minetest.log("action", "An acacia bush sapling grows into a bush at "..
+			minetest.pos_to_string(pos))
+		default.grow_acacia_bush(pos)
+	elseif node.name == "default:pine_bush_sapling" then
+		minetest.log("action", "A pine bush sapling grows into a bush at "..
+			minetest.pos_to_string(pos))
+		default.grow_pine_bush(pos)
+	elseif node.name == "default:emergent_jungle_sapling" then
+		minetest.log("action", "An emergent jungle sapling grows into a tree at "..
+			minetest.pos_to_string(pos))
+		default.grow_new_emergent_jungle_tree(pos)
+	end
+end
+
+minetest.register_lbm({
+	name = "default:convert_saplings_to_node_timer",
+	nodenames = {"default:sapling", "default:junglesapling",
+			"default:pine_sapling", "default:acacia_sapling",
+			"default:aspen_sapling"},
+	action = function(pos)
+		minetest.get_node_timer(pos):start(math.random(300, 1500))
 	end
 })
-
 
 --
 -- Tree generation
@@ -65,27 +119,17 @@ minetest.register_abm({
 
 -- Apple tree and jungle tree trunk and leaves function
 
-local function add_trunk_and_leaves(
-	data, a, pos, tree_cid, leaves_cid, height, size, iters, is_apple_tree
-)
-	-- data : исходные данные узла в форме массива
-	-- a	: VoxelArea:new({MinEdge = minp, MaxEdge = maxp}) обычно minp == maxp
-	-- pos	: координаты ростка
-	-- tree_cid	: исходные данные узла ствола в форме массива
-	-- leaves_cid	: исходные данные узла веток(листьев) в форме массива
-	-- height	: высота ствола
-	-- size		: размер кластера в котором отрабатывают итерации по размещению листвы
-	-- iters	: просто количество итераций для размещения листвы
-	-- is_apple_tree:
-	local x, y, z          = pos.x, pos.y, pos.z
-	local c_air            = minetest.get_content_id("air")
-	local c_ignore         = minetest.get_content_id("ignore")
-	local c_apple          = minetest.get_content_id("default:apple")
+local function add_trunk_and_leaves(data, a, pos, tree_cid, leaves_cid,
+		height, size, iters, is_apple_tree)
+	local x, y, z = pos.x, pos.y, pos.z
+	local c_air = minetest.get_content_id("air")
+	local c_ignore = minetest.get_content_id("ignore")
+	local c_apple = minetest.get_content_id("default:apple")
 
 	-- Trunk
 	data[a:index(x, y, z)] = tree_cid -- Force-place lowest trunk node to replace sapling
 	for yy = y + 1, y + height - 1 do
-		local vi      = a:index(x, yy, z)   -- получаем индекс узла в пространстве Voxel манипулятора (a)
+		local vi = a:index(x, yy, z)
 		local node_id = data[vi]
 		if node_id == c_air or node_id == c_ignore or node_id == leaves_cid then
 			data[vi] = tree_cid
@@ -94,19 +138,19 @@ local function add_trunk_and_leaves(
 
 	-- Force leaves near the trunk
 	for z_dist = -1, 1 do
-		for y_dist = -size, 1 do
-			local vi = a:index(x - 1, y + height + y_dist, z + z_dist)
-			for x_dist = -1, 1 do
-				if data[vi] == c_air or data[vi] == c_ignore then
-					if is_apple_tree and random(1, 8) == 1 then
-						data[vi] = c_apple
-					else
-						data[vi] = leaves_cid
-					end
+	for y_dist = -size, 1 do
+		local vi = a:index(x - 1, y + height + y_dist, z + z_dist)
+		for x_dist = -1, 1 do
+			if data[vi] == c_air or data[vi] == c_ignore then
+				if is_apple_tree and random(1, 8) == 1 then
+					data[vi] = c_apple
+				else
+					data[vi] = leaves_cid
 				end
-				vi = vi + 1
 			end
+			vi = vi + 1
 		end
+	end
 	end
 
 	-- Randomly add leaves in 2x2x2 clusters.
@@ -116,18 +160,18 @@ local function add_trunk_and_leaves(
 		local clust_z = z + random(-size, size - 1)
 
 		for xi = 0, 1 do
-			for yi = 0, 1 do
-				for zi = 0, 1 do
-					local vi = a:index(clust_x + xi, clust_y + yi, clust_z + zi)
-					if data[vi] == c_air or data[vi] == c_ignore then
-						if is_apple_tree and random(1, 8) == 1 then
-							data[vi] = c_apple
-						else
-							data[vi] = leaves_cid
-						end
-					end
+		for yi = 0, 1 do
+		for zi = 0, 1 do
+			local vi = a:index(clust_x + xi, clust_y + yi, clust_z + zi)
+			if data[vi] == c_air or data[vi] == c_ignore then
+				if is_apple_tree and random(1, 8) == 1 then
+					data[vi] = c_apple
+				else
+					data[vi] = leaves_cid
 				end
 			end
+		end
+		end
 		end
 	end
 end
@@ -145,17 +189,18 @@ function default.grow_tree(pos, is_apple_tree, bad)
 		error("Deprecated use of default.grow_tree")
 	end
 
-	local height     = random(4, 5)
-	local c_tree     = minetest.get_content_id("default:tree")
-	local c_leaves   = minetest.get_content_id("default:leaves")
+	local x, y, z = pos.x, pos.y, pos.z
+	local height = random(4, 5)
+	local c_tree = minetest.get_content_id("default:tree")
+	local c_leaves = minetest.get_content_id("default:leaves")
 
-	local vm         = minetest.get_voxel_manip()
+	local vm = minetest.get_voxel_manip()
 	local minp, maxp = vm:read_from_map(
-		{ x = pos.x - 2, y = pos.y, z = pos.z - 2 },
-		{ x = pos.x + 2, y = pos.y + height + 1, z = pos.z + 2 }
+		{x = x - 2, y = y, z = z - 2},
+		{x = x + 2, y = y + height + 1, z = z + 2}
 	)
-	local a          = VoxelArea:new({ MinEdge = minp, MaxEdge = maxp })
-	local data       = vm:get_data()
+	local a = VoxelArea:new({MinEdge = minp, MaxEdge = maxp})
+	local data = vm:get_data()
 
 	add_trunk_and_leaves(data, a, pos, c_tree, c_leaves, height, 2, 8, is_apple_tree)
 
@@ -177,22 +222,23 @@ function default.grow_jungle_tree(pos, bad)
 		error("Deprecated use of default.grow_jungle_tree")
 	end
 
-	local x, y, z        = pos.x, pos.y, pos.z
-	local height         = random(8, 12)
-	local c_air          = minetest.get_content_id("air")
-	local c_ignore       = minetest.get_content_id("ignore")
-	local c_jungletree   = minetest.get_content_id("default:jungletree")
+	local x, y, z = pos.x, pos.y, pos.z
+	local height = random(8, 12)
+	local c_air = minetest.get_content_id("air")
+	local c_ignore = minetest.get_content_id("ignore")
+	local c_jungletree = minetest.get_content_id("default:jungletree")
 	local c_jungleleaves = minetest.get_content_id("default:jungleleaves")
 
-	local vm             = minetest.get_voxel_manip()
-	local minp, maxp     = vm:read_from_map(
-		{ x = pos.x - 3, y = pos.y - 1, z = pos.z - 3 },
-		{ x = pos.x + 3, y = pos.y + height + 1, z = pos.z + 3 }
+	local vm = minetest.get_voxel_manip()
+	local minp, maxp = vm:read_from_map(
+		{x = x - 3, y = y - 1, z = z - 3},
+		{x = x + 3, y = y + height + 1, z = z + 3}
 	)
-	local a              = VoxelArea:new({ MinEdge = minp, MaxEdge = maxp })
-	local data           = vm:get_data()
+	local a = VoxelArea:new({MinEdge = minp, MaxEdge = maxp})
+	local data = vm:get_data()
 
-	add_trunk_and_leaves(data, a, pos, c_jungletree, c_jungleleaves, height, 3, 30, false)
+	add_trunk_and_leaves(data, a, pos, c_jungletree, c_jungleleaves,
+		height, 3, 30, false)
 
 	-- Roots
 	for z_dist = -1, 1 do
@@ -233,47 +279,29 @@ local function add_snow(data, vi, c_air, c_ignore, c_snow)
 	end
 end
 
-function default.grow_pine_tree(pos)
-	local x, y, z        = pos.x, pos.y, pos.z
-	local maxy           = y + random(9, 13) -- Trunk top
+function default.grow_pine_tree(pos, snow)
+	local x, y, z = pos.x, pos.y, pos.z
+	local maxy = y + random(9, 13) -- Trunk top
 
-	local c_air          = minetest.get_content_id("air")
-	local c_ignore       = minetest.get_content_id("ignore")
-	local c_pine_tree    = minetest.get_content_id("default:pine_tree")
-	local c_pine_needles = minetest.get_content_id("default:pine_needles")
-	local c_snow         = minetest.get_content_id("default:snow")
-	local c_snowblock    = minetest.get_content_id("default:snowblock")
-	local c_dirtsnow     = minetest.get_content_id("default:dirt_with_snow")
+	local c_air = minetest.get_content_id("air")
+	local c_ignore = minetest.get_content_id("ignore")
+	local c_pine_tree = minetest.get_content_id("default:pine_tree")
+	local c_pine_needles  = minetest.get_content_id("default:pine_needles")
+	local c_snow = minetest.get_content_id("default:snow")
 
-	local vm             = minetest.get_voxel_manip()
-	local minp, maxp     = vm:read_from_map(
-		{ x = x - 3, y = y - 1, z = z - 3 },
-		{ x = x + 3, y = maxy + 3, z = z + 3 }
+	local vm = minetest.get_voxel_manip()
+	local minp, maxp = vm:read_from_map(
+		{x = x - 3, y = y, z = z - 3},
+		{x = x + 3, y = maxy + 3, z = z + 3}
 	)
-	local a              = VoxelArea:new({ MinEdge = minp, MaxEdge = maxp })
-	local data           = vm:get_data()
+	local a = VoxelArea:new({MinEdge = minp, MaxEdge = maxp})
+	local data = vm:get_data()
 
-	-- Scan for snow nodes near sapling to enable snow on branches
-	local snow           = false
-	for yy = y - 1, y + 1 do
-		for zz = z - 1, z + 1 do
-			local vi = a:index(x - 1, yy, zz)
-			for xx = x - 1, x + 1 do
-				local nodid = data[vi]
-				if nodid == c_snow or nodid == c_snowblock or nodid == c_dirtsnow then
-					snow = true
-				end
-				vi = vi + 1
-			end
-		end
-	end
-
-	local dev
 	-- Upper branches layer
-	dev = 3
+	local dev = 3
 	for yy = maxy - 1, maxy + 1 do
 		for zz = z - dev, z + dev do
-			local vi  = a:index(x - dev, yy, zz)
+			local vi = a:index(x - dev, yy, zz)
 			local via = a:index(x - dev, yy + 1, zz)
 			for xx = x - dev, x + dev do
 				if random() < 0.95 - dev * 0.05 then
@@ -301,16 +329,15 @@ function default.grow_pine_tree(pos)
 
 	-- Lower branches layer
 	local my = 0
-	for i = 1, 20 do
-		-- Random 2x2 squares of needles
+	for i = 1, 20 do -- Random 2x2 squares of needles
 		local xi = x + random(-3, 2)
 		local yy = maxy + random(-6, -5)
 		local zi = z + random(-3, 2)
 		if yy > my then
 			my = yy
 		end
-		for zz = zi, zi + 1 do
-			local vi  = a:index(xi, yy, zz)
+		for zz = zi, zi+1 do
+			local vi = a:index(xi, yy, zz)
 			local via = a:index(xi, yy + 1, zz)
 			for xx = xi, xi + 1 do
 				add_pine_needles(data, vi, c_air, c_ignore, c_snow,
@@ -327,7 +354,7 @@ function default.grow_pine_tree(pos)
 	dev = 2
 	for yy = my + 1, my + 2 do
 		for zz = z - dev, z + dev do
-			local vi  = a:index(x - dev, yy, zz)
+			local vi = a:index(x - dev, yy, zz)
 			local via = a:index(x - dev, yy + 1, zz)
 			for xx = x - dev, x + dev do
 				if random() < 0.95 - dev * 0.05 then
@@ -345,12 +372,13 @@ function default.grow_pine_tree(pos)
 	end
 
 	-- Trunk
-	data[a:index(x, y, z)] = c_pine_tree -- Force-place lowest trunk node to replace sapling
+	-- Force-place lowest trunk node to replace sapling
+	data[a:index(x, y, z)] = c_pine_tree
 	for yy = y + 1, maxy do
-		local vi      = a:index(x, yy, z)
+		local vi = a:index(x, yy, z)
 		local node_id = data[vi]
 		if node_id == c_air or node_id == c_ignore or
-			node_id == c_pine_needles or node_id == c_snow then
+				node_id == c_pine_needles or node_id == c_snow then
 			data[vi] = c_pine_tree
 		end
 	end
@@ -364,40 +392,126 @@ end
 -- New apple tree
 
 function default.grow_new_apple_tree(pos)
-	local path = minetest.get_modpath("default") .. "/schematics/apple_tree_from_sapling.mts"
-	minetest.place_schematic({ x = pos.x - 2, y = pos.y - 1, z = pos.z - 2 }, path, 0, nil, false)
+	local path = minetest.get_modpath("default") ..
+		"/schematics/apple_tree_from_sapling.mts"
+	minetest.place_schematic({x = pos.x - 3, y = pos.y - 1, z = pos.z - 3},
+		path, "random", nil, false)
 end
 
 
 -- New jungle tree
 
 function default.grow_new_jungle_tree(pos)
-	local path = minetest.get_modpath("default") .. "/schematics/jungle_tree_from_sapling.mts"
-	minetest.place_schematic({ x = pos.x - 2, y = pos.y - 1, z = pos.z - 2 }, path, 0, nil, false)
+	local path = minetest.get_modpath("default") ..
+		"/schematics/jungle_tree_from_sapling.mts"
+	minetest.place_schematic({x = pos.x - 2, y = pos.y - 1, z = pos.z - 2},
+		path, "random", nil, false)
+end
+
+
+-- New emergent jungle tree
+
+function default.grow_new_emergent_jungle_tree(pos)
+	local path = minetest.get_modpath("default") ..
+		"/schematics/emergent_jungle_tree_from_sapling.mts"
+	minetest.place_schematic({x = pos.x - 3, y = pos.y - 5, z = pos.z - 3},
+		path, "random", nil, false)
 end
 
 
 -- New pine tree
 
 function default.grow_new_pine_tree(pos)
-	local path = minetest.get_modpath("default") .. "/schematics/pine_tree_from_sapling.mts"
-	minetest.place_schematic({ x = pos.x - 2, y = pos.y - 1, z = pos.z - 2 }, path, 0, nil, false)
+	local path
+	if math.random() > 0.5 then
+		path = minetest.get_modpath("default") ..
+			"/schematics/pine_tree_from_sapling.mts"
+	else
+		path = minetest.get_modpath("default") ..
+			"/schematics/small_pine_tree_from_sapling.mts"
+	end
+	minetest.place_schematic({x = pos.x - 2, y = pos.y - 1, z = pos.z - 2},
+		path, "0", nil, false)
+end
+
+
+-- New snowy pine tree
+
+function default.grow_new_snowy_pine_tree(pos)
+	local path
+	if math.random() > 0.5 then
+		path = minetest.get_modpath("default") ..
+			"/schematics/snowy_pine_tree_from_sapling.mts"
+	else
+		path = minetest.get_modpath("default") ..
+			"/schematics/snowy_small_pine_tree_from_sapling.mts"
+	end
+	minetest.place_schematic({x = pos.x - 2, y = pos.y - 1, z = pos.z - 2},
+		path, "random", nil, false)
 end
 
 
 -- New acacia tree
 
 function default.grow_new_acacia_tree(pos)
-	local path = minetest.get_modpath("default") .. "/schematics/acacia_tree_from_sapling.mts"
-	minetest.place_schematic({ x = pos.x - 4, y = pos.y - 1, z = pos.z - 4 }, path, random, nil, false)
+	local path = minetest.get_modpath("default") ..
+		"/schematics/acacia_tree_from_sapling.mts"
+	minetest.place_schematic({x = pos.x - 4, y = pos.y - 1, z = pos.z - 4},
+		path, "random", nil, false)
 end
+
 
 -- New aspen tree
 
 function default.grow_new_aspen_tree(pos)
-	local path = minetest.get_modpath("default") .. "/schematics/aspen_tree_from_sapling.mts"
-	minetest.place_schematic({ x = pos.x - 2, y = pos.y - 1, z = pos.z - 2 }, path, 0, nil, false)
+	local path = minetest.get_modpath("default") ..
+		"/schematics/aspen_tree_from_sapling.mts"
+	minetest.place_schematic({x = pos.x - 2, y = pos.y - 1, z = pos.z - 2},
+		path, "0", nil, false)
 end
+
+
+-- Bushes do not need 'from sapling' schematic variants because
+-- only the stem node is force-placed in the schematic.
+
+-- Bush
+
+function default.grow_bush(pos)
+	local path = minetest.get_modpath("default") ..
+		"/schematics/bush.mts"
+	minetest.place_schematic({x = pos.x - 1, y = pos.y - 1, z = pos.z - 1},
+		path, "0", nil, false)
+end
+
+-- Blueberry bush
+
+function default.grow_blueberry_bush(pos)
+	local path = minetest.get_modpath("default") ..
+		"/schematics/blueberry_bush.mts"
+	minetest.place_schematic({x = pos.x - 1, y = pos.y, z = pos.z - 1},
+		path, "0", nil, false)
+end
+
+
+-- Acacia bush
+
+function default.grow_acacia_bush(pos)
+	local path = minetest.get_modpath("default") ..
+		"/schematics/acacia_bush.mts"
+	minetest.place_schematic({x = pos.x - 1, y = pos.y - 1, z = pos.z - 1},
+		path, "0", nil, false)
+end
+
+
+-- Pine bush
+
+function default.grow_pine_bush(pos)
+	local path = minetest.get_modpath("default") ..
+		"/schematics/pine_bush.mts"
+	minetest.place_schematic({x = pos.x - 1, y = pos.y - 1, z = pos.z - 1},
+		path, "0", nil, false)
+end
+
 
 -- Large cactus
 
@@ -406,4 +520,88 @@ function default.grow_large_cactus(pos)
 		"/schematics/large_cactus.mts"
 	minetest.place_schematic({x = pos.x - 2, y = pos.y - 1, z = pos.z - 2},
 		path, "random", nil, false)
+end
+
+
+--
+-- Sapling 'on place' function to check protection of node and resulting tree volume
+--
+
+function default.sapling_on_place(itemstack, placer, pointed_thing,
+		sapling_name, minp_relative, maxp_relative, interval)
+	-- Position of sapling
+	local pos = pointed_thing.under
+	local node = minetest.get_node_or_nil(pos)
+	local pdef = node and minetest.registered_nodes[node.name]
+
+	if pdef and pdef.on_rightclick and
+			not (placer and placer:is_player() and
+			placer:get_player_control().sneak) then
+		return pdef.on_rightclick(pos, node, placer, itemstack, pointed_thing)
+	end
+
+	if not pdef or not pdef.buildable_to then
+		pos = pointed_thing.above
+		node = minetest.get_node_or_nil(pos)
+		pdef = node and minetest.registered_nodes[node.name]
+		if not pdef or not pdef.buildable_to then
+			return itemstack
+		end
+	end
+
+	local player_name = placer and placer:get_player_name() or ""
+	-- Check sapling position for protection
+	if minetest.is_protected(pos, player_name) then
+		minetest.record_protection_violation(pos, player_name)
+		return itemstack
+	end
+	-- Check tree volume for protection
+	if minetest.is_area_protected(
+			vector.add(pos, minp_relative),
+			vector.add(pos, maxp_relative),
+			player_name,
+			interval) then
+		minetest.record_protection_violation(pos, player_name)
+		-- Print extra information to explain
+--		minetest.chat_send_player(player_name,
+--			itemstack:get_definition().description .. " will intersect protection " ..
+--			"on growth")
+		minetest.chat_send_player(player_name,
+		    S("@1 will intersect protection on growth.",
+			itemstack:get_definition().description))
+		return itemstack
+	end
+
+	minetest.log("action", player_name .. " places node "
+			.. sapling_name .. " at " .. minetest.pos_to_string(pos))
+
+	local take_item = not minetest.is_creative_enabled(player_name)
+	local newnode = {name = sapling_name}
+	local ndef = minetest.registered_nodes[sapling_name]
+	minetest.set_node(pos, newnode)
+
+	-- Run callback
+	if ndef and ndef.after_place_node then
+		-- Deepcopy place_to and pointed_thing because callback can modify it
+		if ndef.after_place_node(table.copy(pos), placer,
+				itemstack, table.copy(pointed_thing)) then
+			take_item = false
+		end
+	end
+
+	-- Run script hook
+	for _, callback in ipairs(minetest.registered_on_placenodes) do
+		-- Deepcopy pos, node and pointed_thing because callback can modify them
+		if callback(table.copy(pos), table.copy(newnode),
+				placer, table.copy(node or {}),
+				itemstack, table.copy(pointed_thing)) then
+			take_item = false
+		end
+	end
+
+	if take_item then
+		itemstack:take_item()
+	end
+
+	return itemstack
 end

--- a/mods/lord/_overwrites/MTG/default/init.lua
+++ b/mods/lord/_overwrites/MTG/default/init.lua
@@ -1,4 +1,4 @@
-
+local S = default.get_translator
 
 -- default/chests.lua
 
@@ -264,3 +264,314 @@ minetest.register_craft({
 	recipe = "group:wooden",
 	burntime = 5,
 })
+
+
+
+-- default/nodes.lua
+
+minetest.unregister_item("default:silver_sandstone")
+minetest.unregister_item("default:silver_sandstone_brick")
+minetest.unregister_item("default:silver_sandstone_block")
+-- Временно закомментировано. Это неободимо для работы Farming.
+-- Если будет возможно — исправим и восстановим эти строки.
+-- Если нет — удалим "с корнем".
+--[[
+minetest.unregister_item("default:dirt_with_dry_grass")
+minetest.unregister_item("default:dirt_with_rainforest_litter")
+minetest.unregister_item("default:dirt_with_coniferous_litter")
+minetest.unregister_item("default:dry_dirt")
+minetest.unregister_item("default:dry_dirt_with_dry_grass")
+]]
+minetest.unregister_item("default:permafrost")
+minetest.unregister_item("default:permafrost_with_stones")
+minetest.unregister_item("default:permafrost_with_moss")
+minetest.unregister_item("default:silver_sand")
+minetest.unregister_item("default:cave_ice")
+minetest.unregister_item("default:emergent_jungle_sapling")
+minetest.unregister_item("default:pine_tree")
+minetest.unregister_item("default:pine_wood")
+minetest.unregister_item("default:pine_needles")
+minetest.unregister_item("default:pine_sapling")
+minetest.unregister_item("default:acacia_tree")
+minetest.unregister_item("default:acacia_wood")
+minetest.unregister_item("default:acacia_leaves")
+minetest.unregister_item("default:acacia_sapling")
+minetest.unregister_item("default:aspen_tree")
+minetest.unregister_item("default:aspen_wood")
+minetest.unregister_item("default:aspen_leaves")
+minetest.unregister_item("default:aspen_sapling")
+minetest.unregister_item("default:stone_with_tin")
+minetest.unregister_item("default:tinblock")
+minetest.unregister_item("default:bush_stem")
+minetest.unregister_item("default:bush_sapling")
+minetest.unregister_item("default:acacia_bush_stem")
+minetest.unregister_item("default:acacia_bush_leaves")
+minetest.unregister_item("default:acacia_bush_sapling")
+minetest.unregister_item("default:pine_bush_stem")
+minetest.unregister_item("default:pine_bush_needles")
+minetest.unregister_item("default:pine_bush_sapling")
+minetest.unregister_item("default:blueberry_bush_leaves_with_berries")
+minetest.unregister_item("default:blueberry_bush_leaves")
+minetest.unregister_item("default:blueberry_bush_sapling")
+minetest.unregister_item("default:sand_with_kelp")
+minetest.unregister_item("default:coral_green")
+minetest.unregister_item("default:coral_pink")
+minetest.unregister_item("default:coral_cyan")
+minetest.unregister_item("default:coral_brown")
+minetest.unregister_item("default:coral_orange")
+minetest.unregister_item("default:coral_skeleton")
+minetest.unregister_item("default:sign_wall_wood")
+minetest.unregister_item("default:sign_wall_steel")
+minetest.unregister_item("default:fence_acacia_wood")
+minetest.unregister_item("default:fence_pine_wood")
+minetest.unregister_item("default:fence_aspen_wood")
+minetest.unregister_item("default:fence_rail_acacia_wood")
+minetest.unregister_item("default:fence_rail_pine_wood")
+minetest.unregister_item("default:fence_rail_aspen_wood")
+minetest.unregister_item("default:mese_post_light")
+minetest.unregister_item("default:mese_post_light_acacia_wood")
+minetest.unregister_item("default:mese_post_light_junglewood")
+minetest.unregister_item("default:mese_post_light_pine_wood")
+minetest.unregister_item("default:mese_post_light_aspen_wood")
+
+
+-- Наши моделька и интерфейс книжной полки
+
+local bookshelf_formspec =
+	"size[8,9]" ..
+	"list[context;books;0,0;8,2;]" ..
+	"list[current_player;main;0,5;8,4;]" ..
+	"listring[context;books]" ..
+	"listring[current_player;main]" ..
+	"background[-0.5,-0.65;9,10.35;gui_chestbg.png]" ..
+"listcolors[#606060AA;#888;#141318;#30434C;#FFF]"
+
+-- Функция использовалась для другого, но я ее порезал, при этом
+-- решив оставить функцией, а не распихивать по коллбэкам
+local function update_bookshelf(pos)
+	local meta = minetest.get_meta(pos)
+
+	meta:set_string("formspec", bookshelf_formspec)
+	meta:set_string("infotext", S("Bookshelf"))
+end
+
+minetest.override_item("default:bookshelf", {
+	drawtype = "mesh",
+	mesh = "3dbookshelf.obj",
+	tiles = {
+		"default_wood.png",
+		"default_wood.png^3dbookshelf_inside_back.png",
+		"3dbookshelf_books.png",
+	},
+	on_construct = function(pos)
+		local meta = minetest.get_meta(pos)
+		local inv = meta:get_inventory()
+		inv:set_size("books", 8 * 2)
+		update_bookshelf(pos)
+	end,
+	on_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
+		minetest.log("action", player:get_player_name() ..
+			" moves stuff in bookshelf at " .. minetest.pos_to_string(pos))
+		update_bookshelf(pos)
+	end,
+	on_metadata_inventory_put = function(pos, listname, index, stack, player)
+		minetest.log("action", player:get_player_name() ..
+			" puts stuff to bookshelf at " .. minetest.pos_to_string(pos))
+		update_bookshelf(pos)
+	end,
+	on_metadata_inventory_take = function(pos, listname, index, stack, player)
+		minetest.log("action", player:get_player_name() ..
+			" takes stuff from bookshelf at " .. minetest.pos_to_string(pos))
+		update_bookshelf(pos)
+	end,
+})
+
+-- Кактус
+
+minetest.override_item("default:cactus", {
+	drawtype = "nodebox",
+	tiles = {"default_cactus_top.png", "default_cactus_bottom.png", "default_cactus_side.png",
+	"default_cactus_side.png","default_cactus_side.png","default_cactus_side.png"},
+	groups = {snappy = 1, choppy = 3, flammable = 2, plant = 1, oddly_breakable_by_hand = 1, attached_node = 1},
+	sounds = default.node_sound_leaves_defaults(),
+	paramtype = "light",
+	paramtype2 = "none",
+	sunlight_propagates = false,
+	--node_placement_prediction = "",
+	drop = "flowers:cactus_decor",
+	node_box = {
+		type = "fixed",
+		fixed = {
+			{-7/16, -8/16, -7/16,  7/16, 8/16,  7/16}, -- Main body
+			{-8/16, -8/16, -7/16,  8/16, 8/16, -7/16}, -- Spikes
+			{-8/16, -8/16,  7/16,  8/16, 8/16,  7/16}, -- Spikes
+			{-7/16, -8/16, -8/16, -7/16, 8/16,  8/16}, -- Spikes
+			{7/16,  -8/16,  8/16,  7/16, 8/16, -8/16}, -- Spikes
+		},
+	},
+	collision_box = {
+		type = "fixed",
+		fixed = {-7/16, -8/16, -7/16,  7/16, 7/16,  7/16}, -- Main body
+	},
+	selection_box = {
+		type = "fixed",
+		fixed = {
+			{-7/16, -8/16, -7/16, 7/16, 8/16, 7/16},
+		},
+	},
+	after_dig_node = function(pos, node, metadata, digger)
+		default.dig_up(pos, node, digger)
+	end,
+	on_place = nil,
+})
+
+minetest.clear_craft({output = "default:large_cactus_seedling"})
+
+-- Перезапись функции роста большого кактуса на пустую
+
+function default.grow_large_cactus(pos)
+	return nil
+end
+
+-- Ньян-кот
+
+minetest.register_node(":default:nyancat", {
+	description = S("Nyan Cat"),
+	tiles = {"default_nc_side.png", "default_nc_side.png", "default_nc_side.png", "default_nc_side.png",
+	 "default_nc_back.png", "default_nc_front.png"},
+	paramtype2 = "facedir",
+	groups = {cracky = 2},
+	is_ground_content = false,
+	legacy_facedir_simple = true,
+	sounds = default.node_sound_defaults(),
+})
+
+minetest.register_node(":default:nyancat_rainbow", {
+	description = S("Nyan Cat Rainbow"),
+	tiles = {"default_nc_rb.png^[transformR90", "default_nc_rb.png^[transformR90",
+	 "default_nc_rb.png", "default_nc_rb.png"},
+	paramtype2 = "facedir",
+	groups = {cracky = 2},
+	is_ground_content = false,
+	sounds = default.node_sound_defaults(),
+})
+
+-- Перезапись листвы ради модельки и возможности карабкаться
+
+minetest.override_item("default:leaves", {
+	drawtype = "mesh",
+	mesh = "leaves_model.obj",
+	tiles = {"default_leaves.png"},
+	inventory_image = "default_leaves_inv.png",
+	walkable = false,
+	climbable = true,
+})
+
+minetest.override_item("default:jungleleaves", {
+	drawtype = "mesh",
+	mesh = "leaves_model.obj",
+	tiles = {"default_jungleleaves.png"},
+	inventory_image = "default_jungleleaves_inv.png",
+	walkable = false,
+	climbable = true,
+})
+
+-- Какие-то брёвна...
+-- Честно, понятия не имею, для чего они нужны, когда есть
+-- default:tree и default:jungletree.
+
+-- На всякий случай вынес их, вместо того чтобы регистровать alias
+-- с default:tree и default:jungletree.
+
+minetest.register_node(":default:tree_trunk", {
+	description = S("Tree Тrunk"),
+	tiles = { "default_tree_top.png", "default_tree_top.png", "default_tree.png"},
+	paramtype2 = "facedir",
+	is_ground_content = false,
+	drop = "default:tree",
+	groups = {tree = 1, choppy = 2, oddly_breakable_by_hand = 1, not_in_creative_inventory = 1, flammable = 2},
+	sounds = default.node_sound_wood_defaults(),
+	on_place = minetest.rotate_node,
+})
+
+minetest.register_node(":default:jungletree_trunk", {
+	description = S("Jungle Tree Trunk"),
+	tiles = {"default_jungletree_top.png", "default_jungletree_top.png", "default_jungletree.png"},
+	paramtype2 = "facedir",
+	is_ground_content = false,
+	drop = "default:jungletree",
+	groups = {tree = 1, choppy = 2, oddly_breakable_by_hand = 1, not_in_creative_inventory = 1, flammable = 2},
+	sounds = default.node_sound_wood_defaults(),
+	on_place = minetest.rotate_node,
+})
+
+-- Включение возможности падения стволов деревьев
+
+minetest.override_item("default:tree", {
+	on_dig = function(pos, node, digger)
+		default.dig_tree(pos, node, "default:tree", digger, 20, 2, "default:tree")
+	end,
+})
+
+minetest.override_item("default:jungletree", {
+	on_dig = function(pos, node, digger)
+		default.dig_tree(pos, node, "default:jungletree", digger, 20, 2, "default:jungletree")
+	end,
+})
+
+
+-- default/functions.lua
+
+
+-- Падение ствола деревьев вниз при ломании
+
+local falling_trees = minetest.settings:get_bool("falling_trees")
+
+if not falling_trees then
+	if minetest.is_singleplayer() then
+		falling_trees = false
+	else
+		falling_trees = true
+	end
+end
+
+if falling_trees == true then
+	function default.dig_tree(pos, node, name, digger, height, radius, drop)
+		minetest.node_dig(pos, node, digger)
+
+		if minetest.is_protected(pos, digger:get_player_name()) then
+			return
+		end
+
+		local base_y = pos.y
+		for i = 1, (height + 5) do
+			pos.y        = base_y + i
+			local node_i = minetest.get_node(pos)
+			if node_i.name ~= name or i == (height + 5) then
+				minetest.remove_node({ x = pos.x, y = pos.y - 1, z = pos.z })
+				for k = -radius, radius do
+					for l = -radius, radius do
+						for j = 0, 1 do
+							local tree_bellow = minetest.get_node({ x = pos.x + k, y = pos.y - 1, z = pos.z + l })
+							if tree_bellow.name ~= name then
+								local pos1 = { x = pos.x + k, y = pos.y + j, z = pos.z + l }
+								if minetest.get_node(pos1).name == name then
+									minetest.spawn_item(pos1, drop)
+									minetest.remove_node(pos1)
+								end
+							end
+						end
+					end
+				end
+				return
+			elseif node_i.name == name then
+				minetest.set_node({ x = pos.x, y = pos.y - 1, z = pos.z }, { name = name })
+			end
+		end
+	end
+else
+	function default.dig_tree(pos, node, name, digger, height, radius, drop)
+		minetest.node_dig(pos, node, digger)
+		return nil
+	end
+end

--- a/mods/lord/legacy/init.lua
+++ b/mods/lord/legacy/init.lua
@@ -86,7 +86,6 @@ minetest.register_alias("steel_ingot", "default:steel_ingot")
 minetest.register_alias("clay_brick", "default:clay_brick")
 
 minetest.register_alias("default:ladder", "default:ladder_wood")
-minetest.register_alias("default:sign_wall", "default:sign_wall_wood")
 minetest.register_alias("default:sign_wall_wood", "default:sign_wall")
 
 minetest.register_alias("scorched_stuff", "default:dirt")


### PR DESCRIPTION
#267. Основное изменение — обновление `nodes.lua`, а остальное затрагивалось ради работоспособности этого.

Что стоит проверить:

- [x] Рост деревьев из lott 
- [x] Замена земли на **разную** траву
- [x] Работоспособность тростника и кактуса (рост, дроп)
- [x] Звуки льда
- [x] Спаун Nyan-cat-ов
- [x] Падение ствола деревьев
- [ ] Совместимость со старым миром
- [x] Поведение книжных полок

**ВАЖНО**: Обновление затронуло заборчики, поэтому для того, чтобы их хитбокс был чуть выше необходимо в minetest.conf добавить:
`enable_fence_tall = true`

Обновление (возможно) фиксит #252

Появился побочный эффект: снег опадает с деревьев сосны при обновлении ноды

TODO (по-сути, что забыл сделать): 

- [x] Вынести обновлённую модельку книжной полки
- [x] Проходимость листвы яблони и джунглевого дерева
- [ ] ~Разобраться с заборами из других модов~ Выносим в отдельный PR
- [x] Вынести модельку кактуса
