### PR TITLE
Removing temporary changes in `MTG/stairs`

### DIFF
--- a/mods/_minetest_game/stairs/init.lua
+++ b/mods/_minetest_game/stairs/init.lua
@@ -867,8 +867,7 @@ my_register_stair_and_slab(
 	{"default_ice.png"},
 	"Ice Stair",
 	"Ice Slab",
-	--default.node_sound_ice_defaults(),
-	default.node_sound_glass_defaults(), -- Вернуть, когда обновится MTG/default/functions.lua
+	default.node_sound_ice_defaults(),
 	true
 )
 

--- a/mods/lord/_overwrites/MTG/stairs/readme.md
+++ b/mods/lord/_overwrites/MTG/stairs/readme.md
@@ -1,3 +1,1 @@
 ### Переопределения для мода `minetest_game/stairs`
-
-- Временно заменено для совместимости `default.node_sound_ice_defaults()` на `default.node_sound_glass_defaults()` в [minetest_game/stairs/init.lua](../../../../_minetest_game/stairs/init.lua#L870) Нужно вернуть, когда обновится MTG/default/functions.lua


### PR DESCRIPTION
The module `minetest_game/stairs` is fully consistent with commit MTG 5.4.1 (`42baede13fdf855773cc44ce10f4a3ea4e239404`)

Fix: lord-server/lord#510