### PR TITLE
Переработка "расовых" сундуков из lottblocks

### DIFF
--- a/mods/_lott/lottblocks/chests.lua
+++ b/mods/_lott/lottblocks/chests.lua
@@ -42,7 +42,7 @@ local function register_race_chest(name, desc, tiles, owner_race, background, fa
 		on_rightclick         = function(pos, node, clicker, itemstack)
 			local player = clicker:get_player_name()
 			local item   = itemstack:get_name()
-			if races.get_race_and_gender(player)[1] == owner_race then
+			if races.get_race_and_gender(player)[1] == owner_race or minetest.is_creative_enabled(player) then
 				minetest.show_formspec(player, name, default.chest.get_chest_formspec(pos, background))
 			elseif item == "lottblocks:lockpick" then
 				if math.random(1, 4) ~= 3 then

--- a/mods/_lott/lottblocks/chests.lua
+++ b/mods/_lott/lottblocks/chests.lua
@@ -16,368 +16,107 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_node("lottblocks:hobbit_chest", {
-	description           = SL("Hobbit Chest"),
-	tiles                 = {
+-- Регистрация "расового" сундука
+-- Принимает:
+-- - name - название ноды;
+-- - desc - описание ноды;
+-- - tiles - тайлы ноды;
+-- - owner_race - раса, которая может открывать сундук;
+-- - background - текстура фона сундука;
+-- - fail_text - текст, печатающийся при несоответствии расы сундуку.
+local function register_race_chest(name, desc, tiles, owner_race, background, fail_text)
+	minetest.register_node(name, {
+		description           = desc,
+		tiles                 = tiles,
+		paramtype2            = "facedir",
+		groups                = { choppy = 2, oddly_breakable_by_hand = 2, wooden = 1, smallchest = 1 },
+		legacy_facedir_simple = true,
+		is_ground_content     = false,
+		sounds                = default.node_sound_wood_defaults(),
+		on_construct          = function(pos, node, active_object_count, active_object_count_wider)
+			local meta = minetest.get_meta(pos)
+			meta:set_string("infotext", desc)
+			local inv = meta:get_inventory()
+			inv:set_size("main", 8 * 4)
+		end,
+		on_rightclick         = function(pos, node, clicker, itemstack)
+			local player = clicker:get_player_name()
+			local item   = itemstack:get_name()
+			if races.get_race_and_gender(player)[1] == owner_race then
+				minetest.show_formspec(player, name, default.chest.get_chest_formspec(pos, background))
+			elseif item == "lottblocks:lockpick" then
+				if math.random(1, 4) ~= 3 then
+					itemstack:add_wear(65535 / 20)
+					minetest.chat_send_player(player, SL("Lockpick failed"))
+				else
+					itemstack:add_wear(65535 / 18)
+					minetest.show_formspec(player, name, default.chest.get_chest_formspec(pos, background))
+				end
+			else
+				minetest.chat_send_player(player, fail_text)
+			end
+		end,
+		can_dig               = function(pos, player)
+			local meta = minetest.get_meta(pos)
+			local inv  = meta:get_inventory()
+			return inv:is_empty("main")
+		end,
+		on_punch              = function(pos, player)
+			local meta = minetest.get_meta(pos)
+			meta:set_string("infotext", name)
+			meta:set_string("formspec", "")
+		end,
+	})
+end
+
+register_race_chest("lottblocks:hobbit_chest", SL("Hobbit Chest"),
+	{
 		"lottblocks_hobbit_chest_top.png", "lottblocks_hobbit_chest_top.png", "lottblocks_hobbit_chest_side.png",
 		"lottblocks_hobbit_chest_side.png", "lottblocks_hobbit_chest_side.png", "lottblocks_hobbit_chest_front.png",
 	},
-	paramtype2            = "facedir",
-	groups                = { choppy = 2, oddly_breakable_by_hand = 2, wooden = 1, smallchest = 1 },
-	legacy_facedir_simple = true,
-	is_ground_content     = false,
-	sounds                = default.node_sound_wood_defaults(),
-	on_construct          = function(pos, node, active_object_count, active_object_count_wider)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", SL("Hobbit Chest"))
-		local inv = meta:get_inventory()
-		inv:set_size("main", 8 * 4)
-	end,
-	on_rightclick         = function(pos, node, clicker, itemstack)
-		local player = clicker:get_player_name()
-		local item   = itemstack:get_name()
-		if races.get_race_and_gender(player)[1] == "hobbit" then
-			minetest.show_formspec(
-				player, "lottblocks:hobbit_chest", default.chest.get_chest_formspec(pos, "gui_hobbitbg.png")
-			)
-		elseif item == "lottblocks:lockpick" then
-			if math.random(1, 4) ~= 3 then
-				itemstack:add_wear(65535 / 20)
-				minetest.chat_send_player(player, SL("Lockpick failed"))
-			else
-				itemstack:add_wear(65535 / 18)
-				minetest.show_formspec(
-					player, "lottblocks:hobbit_chest", default.chest.get_chest_formspec(pos, "gui_hobbitbg.png")
-				)
-			end
-		else
-			minetest.chat_send_player(player, SL("Only Hobbits can open this kind of chest!"))
-		end
-	end,
-	can_dig               = function(pos, player)
-		local meta = minetest.get_meta(pos)
-		local inv  = meta:get_inventory()
-		return inv:is_empty("main")
-	end,
-	on_punch              = function(pos, player)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", SL("Hobbit Chest"))
-		meta:set_string("formspec", "")
-	end,
-})
+	"hobbit", "gui_hobbitbg.png", SL("Only Hobbits can open this kind of chest!"))
 
-minetest.register_node("lottblocks:gondor_chest", {
-	description           = SL("Gondorian Chest"),
-	tiles                 = {
+register_race_chest("lottblocks:gondor_chest", SL("Gondorian Chest"),
+	{
 		"lottblocks_gondor_chest_top.png", "lottblocks_gondor_chest_bottom.png", "lottblocks_gondor_chest_side.png",
 		"lottblocks_gondor_chest_side.png", "lottblocks_gondor_chest_side.png", "lottblocks_gondor_chest_front.png",
 	},
-	paramtype2            = "facedir",
-	groups                = { choppy = 2, oddly_breakable_by_hand = 2, wooden = 1, smallchest = 1 },
-	legacy_facedir_simple = true,
-	is_ground_content     = false,
-	sounds                = default.node_sound_wood_defaults(),
-	on_construct          = function(pos, node, active_object_count, active_object_count_wider)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", SL("Gondorian Chest"))
-		local inv = meta:get_inventory()
-		inv:set_size("main", 8 * 4)
-	end,
-	on_rightclick         = function(pos, node, clicker, itemstack)
-		local player = clicker:get_player_name()
-		local item   = itemstack:get_name()
-		if races.get_race_and_gender(player)[1] == "man" then
-			minetest.show_formspec(
-				player,
-				"lottblocks:gondor_chest",
-				default.chest.get_chest_formspec(pos, "gui_gondorbg.png")
-			)
-		elseif item == "lottblocks:lockpick" then
-			if math.random(1, 4) ~= 3 then
-				itemstack:add_wear(65535 / 20)
-				minetest.chat_send_player(player, SL("Lockpick failed"))
-			else
-				itemstack:add_wear(65535 / 18)
-				minetest.show_formspec(
-					player, "lottblocks:gondor_chest", default.chest.get_chest_formspec(pos, "gui_gondorbg.png")
-				)
-			end
-		else
-			minetest.chat_send_player(player, SL("Only Humans can open this kind of chest!"))
-		end
-	end,
-	can_dig               = function(pos, player)
-		local meta = minetest.get_meta(pos);
-		local inv  = meta:get_inventory()
-		return inv:is_empty("main")
-	end,
-	on_punch              = function(pos, player)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", SL("Gondorian Chest"))
-		meta:set_string("formspec", "")
-	end,
-})
+	"man", "gui_gondorbg.png", SL("Only Humans can open this kind of chest!"))
 
-minetest.register_node("lottblocks:rohan_chest", {
-	description           = SL("Rohirrim Chest"),
-	tiles                 = {
+register_race_chest("lottblocks:rohan_chest", SL("Rohirrim Chest"),
+	{
 		"lottblocks_rohan_chest_top.png", "lottblocks_rohan_chest_bottom.png", "lottblocks_rohan_chest_side.png",
 		"lottblocks_rohan_chest_side.png", "lottblocks_rohan_chest_side.png", "lottblocks_rohan_chest_front.png",
 	},
-	paramtype2            = "facedir",
-	groups                = { choppy = 2, oddly_breakable_by_hand = 2, wooden = 1, smallchest = 1 },
-	legacy_facedir_simple = true,
-	is_ground_content     = false,
-	sounds                = default.node_sound_wood_defaults(),
-	on_construct          = function(pos, node, active_object_count, active_object_count_wider)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", SL("Rohirrim Chest"))
-		local inv = meta:get_inventory()
-		inv:set_size("main", 8 * 4)
-	end,
-	on_rightclick         = function(pos, node, clicker, itemstack)
-		local player = clicker:get_player_name()
-		local item   = itemstack:get_name()
-		if races.get_race_and_gender(player)[1] == "man" then
-			minetest.show_formspec(
-				player,
-				"lottblocks:rohan_chest",
-				default.chest.get_chest_formspec(pos, "gui_rohanbg.png")
-			)
-		elseif item == "lottblocks:lockpick" then
-			if math.random(1, 4) ~= 3 then
-				itemstack:add_wear(65535 / 20)
-				minetest.chat_send_player(player, SL("Lockpick failed"))
-			else
-				itemstack:add_wear(65535 / 18)
-				minetest.show_formspec(
-					player, "lottblocks:rohan_chest", default.chest.get_chest_formspec(pos, "gui_rohanbg.png")
-				)
-			end
-		else
-			minetest.chat_send_player(player, SL("Only Humans can open this kind of chest!"))
-		end
-	end,
-	can_dig               = function(pos, player)
-		local meta = minetest.get_meta(pos);
-		local inv  = meta:get_inventory()
-		return inv:is_empty("main")
-	end,
-	on_punch              = function(pos, player)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", SL("Rohirrim Chest"))
-		meta:set_string("formspec", "")
-	end,
-})
+	"man", "gui_rohanbg.png", SL("Only Humans can open this kind of chest!"))
 
-minetest.register_node("lottblocks:elfloth_chest", {
-	description           = SL("Elven (Lorien) Chest"),
-	tiles                 = {
+register_race_chest("lottblocks:elfloth_chest", SL("Elven (Lorien) Chest"),
+	{
 		"lottblocks_elf_chest_top.png", "lottblocks_elf_chest_bottom.png", "lottblocks_elf_chest_side.png",
 		"lottblocks_elf_chest_side.png", "lottblocks_elf_chest_side.png", "lottblocks_elf_chest_front.png",
 	},
-	paramtype2            = "facedir",
-	groups                = { choppy = 2, oddly_breakable_by_hand = 2, wooden = 1, smallchest = 1 },
-	legacy_facedir_simple = true,
-	is_ground_content     = false,
-	sounds                = default.node_sound_wood_defaults(),
-	on_construct          = function(pos, node, active_object_count, active_object_count_wider)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", SL("Elven (Lorien) Chest"))
-		local inv = meta:get_inventory()
-		inv:set_size("main", 8 * 4)
-	end,
-	on_rightclick         = function(pos, node, clicker, itemstack)
-		local player = clicker:get_player_name()
-		local item   = itemstack:get_name()
-		if races.get_race_and_gender(player)[1] == "elf" then
-			minetest.show_formspec(
-				player,
-				"lottblocks:elfloth_chest",
-				default.chest.get_chest_formspec(pos, "gui_elfbg.png")
-			)
-		elseif item == "lottblocks:lockpick" then
-			if math.random(1, 4) ~= 3 then
-				itemstack:add_wear(65535 / 20)
-				minetest.chat_send_player(player, SL("Lockpick failed"))
-			else
-				itemstack:add_wear(65535 / 18)
-				minetest.show_formspec(
-					player, "lottblocks:elfloth_chest", default.chest.get_chest_formspec(pos, "gui_elfbg.png")
-				)
-			end
-		else
-			minetest.chat_send_player(player, SL("Only Elves can open this kind of chest!"))
-		end
-	end,
-	can_dig               = function(pos, player)
-		local meta = minetest.get_meta(pos);
-		local inv  = meta:get_inventory()
-		return inv:is_empty("main")
-	end,
-	on_punch              = function(pos, player)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", SL("Elven (Lorien) Chest"))
-		meta:set_string("formspec", "")
-	end,
-})
+	"elf", "gui_elfbg.png", SL("Only Elves can open this kind of chest!"))
 
-minetest.register_node("lottblocks:elfmirk_chest", {
-	description           = SL("Elven (Mirkwood) Chest"),
-	tiles                 = {
+register_race_chest("lottblocks:elfmirk_chest", SL("Elven (Mirkwood) Chest"),
+	{
 		"lottblocks_elf_chest_top.png", "lottblocks_elf_chest_bottom.png", "lottblocks_elf_chest_side.png",
 		"lottblocks_elf_chest_side.png", "lottblocks_elf_chest_side.png", "lottblocks_elf_chest_front.png",
 	},
-	paramtype2            = "facedir",
-	groups                = { choppy = 2, oddly_breakable_by_hand = 2, wooden = 1, smallchest = 1 },
-	legacy_facedir_simple = true,
-	is_ground_content     = false,
-	sounds                = default.node_sound_wood_defaults(),
-	on_construct          = function(pos, node, active_object_count, active_object_count_wider)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", SL("Elven (Mirkwood) Chest"))
-		local inv = meta:get_inventory()
-		inv:set_size("main", 8 * 4)
-	end,
-	on_rightclick         = function(pos, node, clicker, itemstack)
-		local player = clicker:get_player_name()
-		local item   = itemstack:get_name()
-		if races.get_race_and_gender(player)[1] == "elf" then
-			minetest.show_formspec(
-				player,
-				"lottblocks:elfmirk_chest",
-				default.chest.get_chest_formspec(pos, "gui_elfbg.png")
-			)
-		elseif item == "lottblocks:lockpick" then
-			if math.random(1, 4) ~= 3 then
-				itemstack:add_wear(65535 / 20)
-				minetest.chat_send_player(player, SL("Lockpick failed"))
-			else
-				itemstack:add_wear(65535 / 18)
-				minetest.show_formspec(
-					player, "lottblocks:elfmirk_chest", default.chest.get_chest_formspec(pos, "gui_elfbg.png")
-				)
-			end
-		else
-			minetest.chat_send_player(player, SL("Only Elves can open this kind of chest!"))
-		end
-	end,
-	can_dig               = function(pos, player)
-		local meta = minetest.get_meta(pos);
-		local inv  = meta:get_inventory()
-		return inv:is_empty("main")
-	end,
-	on_punch              = function(pos, player)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", SL("Elven (Mirkwood) Chest"))
-		meta:set_string("formspec", "")
-	end,
-})
+	"elf", "gui_elfbg.png", SL("Only Elves can open this kind of chest!"))
 
-minetest.register_node("lottblocks:mordor_chest", {
-	description           = SL("Mordor Chest"),
-	tiles                 = {
+register_race_chest("lottblocks:mordor_chest", SL("Mordor Chest"),
+	{
 		"lottblocks_mordor_chest_top.png", "lottblocks_mordor_chest_top.png", "lottblocks_mordor_chest_side.png",
 		"lottblocks_mordor_chest_side.png", "lottblocks_mordor_chest_side.png", "lottblocks_mordor_chest_front.png",
 	},
-	paramtype2            = "facedir",
-	groups                = { choppy = 2, oddly_breakable_by_hand = 2, wooden = 1, smallchest = 1 },
-	legacy_facedir_simple = true,
-	is_ground_content     = false,
-	sounds                = default.node_sound_wood_defaults(),
-	on_construct          = function(pos, node, active_object_count, active_object_count_wider)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", SL("Mordor Chest"))
-		local inv = meta:get_inventory()
-		inv:set_size("main", 8 * 4)
-	end,
-	on_rightclick         = function(pos, node, clicker, itemstack)
-		local player = clicker:get_player_name()
-		local item   = itemstack:get_name()
-		if races.get_race_and_gender(player)[1] == "orc" then
-			minetest.show_formspec(
-				player,
-				"lottblocks:mordor_chest",
-				default.chest.get_chest_formspec(pos, "gui_mordorbg.png")
-			)
-		elseif item == "lottblocks:lockpick" then
-			if math.random(1, 4) ~= 3 then
-				itemstack:add_wear(65535 / 20)
-				minetest.chat_send_player(player, SL("Lockpick failed"))
-			else
-				itemstack:add_wear(65535 / 18)
-				minetest.show_formspec(
-					player, "lottblocks:mordor_chest", default.chest.get_chest_formspec(pos, "gui_mordorbg.png")
-				)
-			end
-		else
-			minetest.chat_send_player(player, SL("Only Orcs can open this kind of chest!"))
-		end
-	end,
-	can_dig               = function(pos, player)
-		local meta = minetest.get_meta(pos);
-		local inv  = meta:get_inventory()
-		return inv:is_empty("main")
-	end,
-	on_punch              = function(pos, player)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", SL("Mordor Chest"))
-		meta:set_string("formspec", "")
-	end,
-})
+	"orc", "gui_mordorbg.png", SL("Only Orcs can open this kind of chest!"))
 
-minetest.register_node("lottblocks:angmar_chest", {
-	description           = SL("Angmar Chest"),
-	tiles                 = {
+register_race_chest("lottblocks:angmar_chest", SL("Angmar Chest"),
+	{
 		"lottblocks_angmar_chest_top.png", "lottblocks_angmar_chest_top.png", "lottblocks_angmar_chest_side.png",
 		"lottblocks_angmar_chest_side.png", "lottblocks_angmar_chest_side.png", "lottblocks_angmar_chest_front.png",
 	},
-	paramtype2            = "facedir",
-	groups                = { choppy = 2, oddly_breakable_by_hand = 2, wooden = 1, smallchest = 1 },
-	legacy_facedir_simple = true,
-	is_ground_content     = false,
-	sounds                = default.node_sound_wood_defaults(),
-	on_construct          = function(pos, node, active_object_count, active_object_count_wider)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", SL("Angmar Chest"))
-		local inv = meta:get_inventory()
-		inv:set_size("main", 8 * 4)
-	end,
-	on_rightclick         = function(pos, node, clicker, itemstack)
-		local player = clicker:get_player_name()
-		local item   = itemstack:get_name()
-		if races.get_race_and_gender(player)[1] == "orc" then
-			minetest.show_formspec(
-				player,
-				"lottblocks:angmar_chest",
-				default.chest.get_chest_formspec(pos, "gui_angmarbg.png")
-			)
-		elseif item == "lottblocks:lockpick" then
-			if math.random(1, 4) ~= 3 then
-				itemstack:add_wear(65535 / 20)
-				minetest.chat_send_player(player, SL("Lockpick failed"))
-			else
-				itemstack:add_wear(65535 / 18)
-				minetest.show_formspec(
-					player, "lottblocks:angmar_chest", default.chest.get_chest_formspec(pos, "gui_angmarbg.png")
-				)
-			end
-		else
-			minetest.chat_send_player(player, SL("Only Orcs can open this kind of chest!"))
-		end
-	end,
-	can_dig               = function(pos, player)
-		local meta = minetest.get_meta(pos);
-		local inv  = meta:get_inventory()
-		return inv:is_empty("main")
-	end,
-	--backwards compatibility: punch to set formspec
-	on_punch              = function(pos, player)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", SL("Angmar Chest"))
-		meta:set_string("formspec", "")
-	end,
-})
+	"orc", "gui_angmarbg.png", SL("Only Orcs can open this kind of chest!"))
 
 minetest.register_craft({
 	output = "lottblocks:hobbit_chest",


### PR DESCRIPTION
Дублирование кода регистрации "расовых" сундуков устранено путём добавления одной регистрирующей функции, плюсом исправлен давнишний баг с отмычкой (#170).