### PR TITLE
Исправление опадения листьев

### DIFF
--- a/mods/_lott/lottplants/nodes.lua
+++ b/mods/_lott/lottplants/nodes.lua
@@ -1044,6 +1044,73 @@ minetest.register_node("lottplants:yavannamirefruit", {
 	end,
 })
 
+-- LEAFDECAY
+-- Регистрация опадающей листвы и др.
+
+-- Alders / Ольха
+default.register_leafdecay({
+	trunks = {"lottplants:aldertree"},
+	leaves = {"lottplants:alderleaf"},
+	radius = 2,
+})
+
+default.register_leafdecay({
+	trunks = {"default:tree"},
+	leaves = {
+		"lottplants:appleleaf", "default:leaves", "default:apple", -- Apple Tree / Яблоня
+		"lottplants:beechleaf", -- Beeches / Бук
+		"lottplants:culumaldaleaf", "lottplants:yellowflowers", -- Culumalda / Кулумальда
+		"lottplants:elmleaf", -- Elms / Вяз
+		"lottplants:plumleaf", "lottplants:plum", -- Plum Tree / Слива
+		"lottplants:rowanleaf", "lottplants:rowanberry", -- Rowans / Рябина
+		"lottplants:whiteleaf", -- White Tree / Белое дерево
+		"lottplants:yavannamireleaf", "lottplants:yavannamirefruit", -- Yavannamire / Йаванамирэ
+	},
+	radius = 6, -- такая большая цифра только из-за бука
+})
+
+-- Lebethron / Лебетрон
+default.register_leafdecay({
+	trunks = {"lottplants:lebethrontree"},
+	leaves = {"lottplants:lebethronleaf"},
+	radius = 2,
+})
+
+-- Birches / Береза
+default.register_leafdecay({
+	trunks = {"lottplants:birchtree"},
+	leaves = {"lottplants:birchleaf"},
+	radius = 3,
+})
+
+-- Firs / Ель
+default.register_leafdecay({
+	trunks = {"lottplants:firtree"},
+	leaves = {"lottplants:firleaf"},
+	radius = 4,
+})
+
+-- (Young) Mallorn / (Молодой) маллорн
+default.register_leafdecay({
+	trunks = {"lottplants:mallorntree", "lottplants:mallorntree_young"},
+	leaves = {"lottplants:mallornleaf"},
+	radius = 2,
+})
+
+-- Pines / Сосна
+default.register_leafdecay({
+	trunks = {"lottplants:pinetree"},
+	leaves = {"lottplants:pineleaf"},
+	radius = 2,
+})
+
+-- Mirk Large/Small / Большое/Малое дерево Лихолесья
+default.register_leafdecay({
+	trunks = {"default:jungletree"},
+	leaves = {"lottplants:mirkleaf"},
+	radius = 2,
+})
+
 --Wood
 
 minetest.register_node("lottplants:pinewood", {


### PR DESCRIPTION
Исправление опадения листьев (#662) из-за изменения API MTG/default. Теперь для этого механизма используется функция `default.register_leafdecay`. Возможно придётся вернуться к ABM, так как бук с его раскидистыми листьями всё портит.

Протестировано:

- [X] Alders / Ольха
- [X] Apple Tree / Яблоня
- [X] Beeches / Бук
- [X] Culumalda / Кулумальда
- [X] Elms / Вяз
- [X] Plum Tree / Слива
- [X] Rowans / Рябина
- [X] White Tree / Белое дерево
- [X] Yavannamire / Йаванамирэ
- [X] Birches / Береза
- [X] Lebethron / Лебетрон
- [X] Firs / Ель
- [X] (Young) Mallorn / (Молодой) маллорн
- [X] Pines / Сосна
- [X] Mirk Large/Small / Большое/Малое дерево Лихолесья
