### PR TITLE
Факела не гаснут в воде (fix 551)

### DIFF
--- a/mods/_lott/lottother/init.lua
+++ b/mods/_lott/lottother/init.lua
@@ -28,6 +28,22 @@ minetest.register_node("lottother:blue_torch", {
 	sunlight_propagates = true,
 	is_ground_content   = false,
 	walkable            = false,
+	floodable           = true,
+	on_flood = function(pos, oldnode, newnode) -- Взято из default/torch.lua
+		minetest.add_item(pos, ItemStack("lottother:blue_torch 1"))
+		-- Play flame-extinguish sound if liquid is not an 'igniter'
+		local nodedef = minetest.registered_items[newnode.name]
+		if not (nodedef and nodedef.groups and
+				nodedef.groups.igniter and nodedef.groups.igniter > 0) then
+			minetest.sound_play(
+				"default_cool_lava",
+				{pos = pos, max_hear_distance = 16, gain = 0.1},
+				true
+			)
+		end
+		-- Remove the torch node
+		return false
+	end,
 	light_source        = LIGHT_MAX - 1,
 	selection_box       = {
 		type        = "wallmounted",
@@ -63,6 +79,22 @@ minetest.register_node("lottother:orc_torch", {
 	sunlight_propagates = true,
 	is_ground_content   = false,
 	walkable            = false,
+	floodable           = true,
+	on_flood = function(pos, oldnode, newnode) -- Взято из default/torch.lua
+		minetest.add_item(pos, ItemStack("lottother:orc_torch 1"))
+		-- Play flame-extinguish sound if liquid is not an 'igniter'
+		local nodedef = minetest.registered_items[newnode.name]
+		if not (nodedef and nodedef.groups and
+				nodedef.groups.igniter and nodedef.groups.igniter > 0) then
+			minetest.sound_play(
+				"default_cool_lava",
+				{pos = pos, max_hear_distance = 16, gain = 0.1},
+				true
+			)
+		end
+		-- Remove the torch node
+		return false
+	end,
 	light_source        = LIGHT_MAX - 3,
 	selection_box       = {
 		type        = "wallmounted",

--- a/mods/_various/torches/mt_style.lua
+++ b/mods/_various/torches/mt_style.lua
@@ -54,6 +54,22 @@ minetest.register_node("torches:blue_floor", {
 	paramtype2 = "wallmounted",
 	sunlight_propagates = true,
 	walkable = false,
+	floodable = true,
+	on_flood = function(pos, oldnode, newnode) -- Взято из default/torch.lua
+		minetest.add_item(pos, ItemStack("lottother:blue_torch 1"))
+		-- Play flame-extinguish sound if liquid is not an 'igniter'
+		local nodedef = minetest.registered_items[newnode.name]
+		if not (nodedef and nodedef.groups and
+				nodedef.groups.igniter and nodedef.groups.igniter > 0) then
+			minetest.sound_play(
+				"default_cool_lava",
+				{pos = pos, max_hear_distance = 16, gain = 0.1},
+				true
+			)
+		end
+		-- Remove the torch node
+		return false
+	end,
 	light_source = 14,
 	groups = {choppy=2, dig_immediate=3, flammable=1, not_in_creative_inventory=1, attached_node=1, torch=1},
 	drop = "lottother:blue_torch",
@@ -78,6 +94,22 @@ minetest.register_node("torches:blue_wall", {
 	paramtype2 = "wallmounted",
 	sunlight_propagates = true,
 	walkable = false,
+	floodable = true,
+	on_flood = function(pos, oldnode, newnode) -- Взято из default/torch.lua
+		minetest.add_item(pos, ItemStack("lottother:blue_torch 1"))
+		-- Play flame-extinguish sound if liquid is not an 'igniter'
+		local nodedef = minetest.registered_items[newnode.name]
+		if not (nodedef and nodedef.groups and
+				nodedef.groups.igniter and nodedef.groups.igniter > 0) then
+			minetest.sound_play(
+				"default_cool_lava",
+				{pos = pos, max_hear_distance = 16, gain = 0.1},
+				true
+			)
+		end
+		-- Remove the torch node
+		return false
+	end,
 	light_source = 14,
 	groups = {choppy=2, dig_immediate=3, flammable=1, not_in_creative_inventory=1, attached_node=1, torch=1},
 	drop = "lottother:blue_torch",
@@ -162,6 +194,22 @@ minetest.register_node("torches:orc_floor", {
 	paramtype2 = "wallmounted",
 	sunlight_propagates = true,
 	walkable = false,
+	floodable = true,
+	on_flood = function(pos, oldnode, newnode) -- Взято из default/torch.lua
+		minetest.add_item(pos, ItemStack("lottother:orc_torch 1"))
+		-- Play flame-extinguish sound if liquid is not an 'igniter'
+		local nodedef = minetest.registered_items[newnode.name]
+		if not (nodedef and nodedef.groups and
+				nodedef.groups.igniter and nodedef.groups.igniter > 0) then
+			minetest.sound_play(
+				"default_cool_lava",
+				{pos = pos, max_hear_distance = 16, gain = 0.1},
+				true
+			)
+		end
+		-- Remove the torch node
+		return false
+	end,
 	light_source = 8,
 	groups = {choppy=2, dig_immediate=3, flammable=1, not_in_creative_inventory=1, attached_node=1, torch=1},
 	drop = "lottother:orc_torch",
@@ -186,6 +234,22 @@ minetest.register_node("torches:orc_wall", {
 	paramtype2 = "wallmounted",
 	sunlight_propagates = true,
 	walkable = false,
+	floodable = true,
+	on_flood = function(pos, oldnode, newnode) -- Взято из default/torch.lua
+		minetest.add_item(pos, ItemStack("lottother:orc_torch 1"))
+		-- Play flame-extinguish sound if liquid is not an 'igniter'
+		local nodedef = minetest.registered_items[newnode.name]
+		if not (nodedef and nodedef.groups and
+				nodedef.groups.igniter and nodedef.groups.igniter > 0) then
+			minetest.sound_play(
+				"default_cool_lava",
+				{pos = pos, max_hear_distance = 16, gain = 0.1},
+				true
+			)
+		end
+		-- Remove the torch node
+		return false
+	end,
 	light_source = 8,
 	groups = {choppy=2, dig_immediate=3, flammable=1, not_in_creative_inventory=1, attached_node=1, torch=1},
 	drop = "lottother:orc_torch",

--- a/mods/lord/lord_homedecor/furniture_medieval.lua
+++ b/mods/lord/lord_homedecor/furniture_medieval.lua
@@ -78,6 +78,22 @@ lord_homedecor.register("torch_wall", {
 	use_texture_alpha = "clip",
 	inventory_image="forniture_torch_inv.png",
 	walkable = false,
+	floodable = true,
+	on_flood = function(pos, oldnode, newnode)
+		minetest.add_item(pos, ItemStack("lord_homedecor:torch_wall 1"))
+		-- Play flame-extinguish sound if liquid is not an 'igniter'
+		local nodedef = minetest.registered_items[newnode.name]
+		if not (nodedef and nodedef.groups and
+				nodedef.groups.igniter and nodedef.groups.igniter > 0) then
+			minetest.sound_play(
+				"default_cool_lava",
+				{pos = pos, max_hear_distance = 16, gain = 0.1},
+				true
+			)
+		end
+		-- Remove the torch node
+		return false
+	end,
 	light_source = 14,
 	selection_box = {
 		type = "fixed",


### PR DESCRIPTION
**Описание PR:**

Исправлен баг, теперь 
`lottother:blue_torch`
`torches:blue_floor`
`torches:blue_wall`

`lottother:orc_torch`
`torches:orc_floor`
`torches:orc_wall`

`lord_homedecor:torch_wall`

Гаснут в воде

**Рекомендации к тесту:**

Поместить вышеупомянутые ноды в воду

**Дополнительная информация:**

fixes #551

Примч. к ревью: я не стал выносить функцию, записанную в on_flood по причинам того, что факелы разнесы в разные файлы, это видно по названию, а так же для разного типа факела в функции меянется итем для дропа. Функцию я взял из `default/torch.lua`.
