### PR TITLE
Add core_callbacks

### DIFF
--- a/mods/lord/lordlib/core_functions.lua
+++ b/mods/lord/lordlib/core_functions.lua
@@ -69,13 +69,19 @@ end
 --- @param player ObjRef - игрок
 --- @param control_name string - кнопка из списка controls
 lord.reset_hold_time = function(player, control_name)
-	if not player then return end
+	if not player then
+		return
+	end
 
-	if not control_name then return end
+	if not control_name then
+		return
+	end
 
 	local player_name = player:get_player_name()
 
-	if not player_name then return end
+	if not player_name then
+		return
+	end
 
 	lord.players[player_name].controls[control_name][2] = minetest.get_us_time()/MICROSECONDS
 end
@@ -85,7 +91,9 @@ lord.players = {}
 minetest.register_on_joinplayer(function(player)
 	local player_name = player:get_player_name()
 
-	if not player_name then return end
+	if not player_name then
+		return
+	end
 
 	lord.players[player_name] = {
 		controls = {
@@ -110,7 +118,9 @@ end)
 minetest.register_on_leaveplayer(function(player)
 	local player_name = player:get_player_name()
 
-	if not player_name then return end
+	if not player_name then
+		return
+	end
 
 	lord.players[player_name] = nil
 end)

--- a/mods/lord/lordlib/core_functions.lua
+++ b/mods/lord/lordlib/core_functions.lua
@@ -7,6 +7,10 @@ local MICROSECONDS = 1000000
 -- Нажатие
 lord.registered_on_press = {}
 
+--- register_on_press(player, control_name)
+--- Срабатывает, когда игрок нажимает кнопку
+--- * player - игрок
+--- * control_name - кнопка из списка controls
 lord.register_on_press = function(func)
 	table.insert(lord.registered_on_press, func)
 end
@@ -14,6 +18,11 @@ end
 -- Отпуск
 lord.registered_on_release = {}
 
+--- register_on_release(player, control_name, release_time)
+--- Срабатывает, когда игрок отпускает кнопку
+--- * player - игрок
+--- * control_name - кнопка из списка controls
+--- * release_time - время удержания кнопки до того, как её отпустили
 lord.register_on_release = function(func)
 	table.insert(lord.registered_on_release, func)
 end
@@ -21,6 +30,12 @@ end
 -- Удержание
 lord.registered_on_hold = {}
 
+--- register_on_hold(player, control_name, hold_time, dtime)
+--- Срабатывает, когда игрок удерживает какую-то кнопку из списка controls
+--- * player - игрок
+--- * control_name - кнопка из списка controls
+--- * hold_time - время удержания кнопки
+--- * dtime - время между прошлым и нынешним вызовом
 lord.register_on_hold = function(func)
 	table.insert(lord.registered_on_hold, func)
 end
@@ -28,6 +43,11 @@ end
 -- Смена индекса предмета в руке
 lord.registered_on_wield_index_change = {}
 
+--- register_on_wield_index_change(player, player_wield_index, player_last_wield_index)
+--- Вызывается, когда индекс предмета в руке изменяется
+--- * player - игрок
+--- * player_wield_index - текущий индекс предмета в руке
+--- * player_last_wield_index - прошлый индекс предмета в руке
 lord.register_on_wield_index_change = function(func)
 	table.insert(lord.registered_on_wield_index_change, func)
 end
@@ -101,7 +121,7 @@ function call_hold(player, player_last_controls, control_name, dtime)
 	end
 end
 
--- Вызов каллбэков смены индекса предмета в руке
+-- Вызов каллбэков отпуска кнопки
 function call_release(player, player_last_controls, control_name)
 	-- Время, сколько была нажата кнопка
 	local release_time = minetest.get_us_time()/MICROSECONDS-player_last_controls[control_name][2]

--- a/mods/lord/lordlib/core_functions.lua
+++ b/mods/lord/lordlib/core_functions.lua
@@ -1,59 +1,71 @@
 -- core functions
 -- Прямиком из lord2
 
--- Callbacks
-core_callback = {}
+-- Для перевода микросекунд в секунды
+local MICROSECONDS = 1000000
 
 -- Нажатие
-core_callback.registered_on_press = {}
+lord.registered_on_press = {}
 
-core_callback.register_on_press = function(func)
-	core_callback.registered_on_press[#core_callback.registered_on_press+1] = func
+lord.register_on_press = function(func)
+	table.insert(lord.registered_on_press, func)
 end
 
 -- Отпуск
-core_callback.registered_on_release = {}
+lord.registered_on_release = {}
 
-core_callback.register_on_release = function(func)
-	core_callback.registered_on_release[#core_callback.registered_on_release+1] = func
+lord.register_on_release = function(func)
+	table.insert(lord.registered_on_release, func)
 end
 
 -- Удержание
-core_callback.registered_on_hold = {}
+lord.registered_on_hold = {}
 
-core_callback.register_on_hold = function(func)
-	core_callback.registered_on_hold[#core_callback.registered_on_hold+1]=func
+lord.register_on_hold = function(func)
+	table.insert(lord.registered_on_hold, func)
 end
 
 -- Смена индекса предмета в руке
-core_callback.registered_on_wield_index_change = {}
+lord.registered_on_wield_index_change = {}
 
-core_callback.register_on_wield_index_change = function(func)
-	core_callback.registered_on_wield_index_change[#core_callback.registered_on_wield_index_change+1]=func
+lord.register_on_wield_index_change = function(func)
+	table.insert(lord.registered_on_wield_index_change, func)
 end
 
-core_callback.reset_hold_time = function(player, control_name)
+-- Сброс времени удержания для кнопки
+lord.reset_hold_time = function(player, control_name)
+	if not player then return end
+
+	if not control_name then return end
+
 	local player_name = player:get_player_name()
-	core_callback.players[player_name].controls[control_name][2] = minetest.get_us_time()/1000000
+
+	if not player_name then return end
+
+	lord.players[player_name].controls[control_name][2] = minetest.get_us_time()/MICROSECONDS
 end
 
-core_callback.players = {}
+lord.players = {}
 
 minetest.register_on_joinplayer(function(player)
-	core_callback.players[player:get_player_name()] = {
+	local player_name = player:get_player_name()
+
+	if not player_name then return end
+
+	lord.players[player_name] = {
 		controls = {
-			jump = {false},
-			right = {false},
-			left = {false},
-			LMB = {false},
-			RMB = {false},
-			sneak = {false},
-			aux1 = {false},
-			down = {false},
-			up = {false},
-			zoom = {false},
-			dig = {false},
-			place = {false},
+			jump = {false, 0},
+			right = {false, 0},
+			left = {false, 0},
+			LMB = {false, 0},
+			RMB = {false, 0},
+			sneak = {false, 0},
+			aux1 = {false, 0},
+			down = {false, 0},
+			up = {false, 0},
+			zoom = {false, 0},
+			dig = {false, 0},
+			place = {false, 0},
 		},
 
 		wield_index = 0
@@ -61,51 +73,82 @@ minetest.register_on_joinplayer(function(player)
 end)
 
 minetest.register_on_leaveplayer(function(player)
-	core_callback.players[player:get_player_name()] = nil
+	local player_name = player:get_player_name()
+
+	if not player_name then return end
+
+	lord.players[player_name] = nil
 end)
+
+-- Вызов каллбэков нажатия клавиши
+function call_press(player, player_last_controls, control_name)
+	-- Время, когда была нажата кнопка
+	local press_time = minetest.get_us_time()/MICROSECONDS
+
+	for _, func in pairs(lord.registered_on_press) do
+		func(player, control_name)
+	end
+	player_last_controls[control_name] = {true, press_time}
+end
+
+-- Вызов каллбэков удержания клавиши
+function call_hold(player, player_last_controls, control_name, dtime)
+	-- Время, когда была нажата кнопка вычитается из текущего, чтобы получить длительность нажатия
+	local hold_time = minetest.get_us_time()/MICROSECONDS-player_last_controls[control_name][2]
+
+	for _, func in pairs(lord.registered_on_hold) do
+		func(player, control_name, hold_time, dtime)
+	end
+end
+
+-- Вызов каллбэков смены индекса предмета в руке
+function call_release(player, player_last_controls, control_name)
+	-- Время, сколько была нажата кнопка
+	local release_time = minetest.get_us_time()/MICROSECONDS-player_last_controls[control_name][2]
+
+	for _, func in pairs(lord.registered_on_release) do
+		func(player, control_name, release_time)
+	end
+	player_last_controls[control_name] = {false, 0}
+end
 
 minetest.register_globalstep(function(dtime)
 	for _, player in pairs(minetest.get_connected_players()) do
 		local player_name = player:get_player_name()
-		local player_controls = player:get_player_control()
-		local player_last_controls = core_callback.players[player_name].controls
-		local player_wield_index = player:get_wield_index()
-		local player_last_wield_index = core_callback.players[player_name].wield_index
+		if player_name ~= nil then
+			local player_controls = player:get_player_control()
+			local player_last_controls = lord.players[player_name].controls
+			local player_wield_index = player:get_wield_index()
+			local player_last_wield_index = lord.players[player_name].wield_index
 
-		for control_name, control_value in pairs(player_controls) do
-			if not player_last_controls then
-				break
+			for control_name, control_value in pairs(player_controls) do
+				if not player_last_controls then
+					break
+				end
+
+				-- Нажатие
+				if (control_value == true) and (player_last_controls[control_name][1] == false) then
+					call_press(player, player_last_controls, control_name)
+
+				-- Удержание
+				elseif (control_value == true) and (player_last_controls[control_name][1] == true) then
+					call_hold(player, player_last_controls, control_name, dtime)
+
+				-- Отпуск
+				elseif (control_value == false) and (player_last_controls[control_name][1] == true) then
+					call_release(player, player_last_controls, control_name)
+				end
 			end
 
-			-- Нажатие
-			if (control_value == true) and (player_last_controls[control_name][1] == false) then
-				for _, func in pairs(core_callback.registered_on_press) do
-					func(player, control_name)
+			-- Вызов каллбэков смены индекса предмета в руке
+			if player_wield_index ~= player_last_wield_index then
+				for _, func in pairs(lord.registered_on_wield_index_change) do
+					func(player, player_wield_index, player_last_wield_index)
 				end
-				player_last_controls[control_name] = {true, minetest.get_us_time()/1000000}
-
-			-- Удержание
-			elseif (control_value == true) and (player_last_controls[control_name][1] == true) then
-				for _, func in pairs(core_callback.registered_on_hold) do
-					func(player, control_name, minetest.get_us_time()/1000000-player_last_controls[control_name][2], dtime)
-				end
-
-			-- Отпуск
-			elseif (control_value == false) and (player_last_controls[control_name][1] == true) then
-				for _, func in pairs(core_callback.registered_on_release) do
-					func(player, control_name, minetest.get_us_time()/1000000-player_last_controls[control_name][2])
-				end
-				player_last_controls[control_name] = {false}
+				player_last_wield_index = player_wield_index
 			end
+			lord.players[player_name].controls = player_last_controls
+			lord.players[player_name].wield_index = player_last_wield_index
 		end
-
-		if player_wield_index ~= player_last_wield_index then
-			for _, func in pairs(core_callback.registered_on_wield_index_change) do
-				func(player, player_wield_index, player_last_wield_index)
-			end
-			player_last_wield_index = player_wield_index
-		end
-		core_callback.players[player_name].controls = player_last_controls
-		core_callback.players[player_name].wield_index = player_last_wield_index
 	end
 end)

--- a/mods/lord/lordlib/core_functions.lua
+++ b/mods/lord/lordlib/core_functions.lua
@@ -1,0 +1,111 @@
+-- core functions
+-- Прямиком из lord2
+
+-- Callbacks
+core_callback = {}
+
+-- Нажатие
+core_callback.registered_on_press = {}
+
+core_callback.register_on_press = function(func)
+	core_callback.registered_on_press[#core_callback.registered_on_press+1] = func
+end
+
+-- Отпуск
+core_callback.registered_on_release = {}
+
+core_callback.register_on_release = function(func)
+	core_callback.registered_on_release[#core_callback.registered_on_release+1] = func
+end
+
+-- Удержание
+core_callback.registered_on_hold = {}
+
+core_callback.register_on_hold = function(func)
+	core_callback.registered_on_hold[#core_callback.registered_on_hold+1]=func
+end
+
+-- Смена индекса предмета в руке
+core_callback.registered_on_wield_index_change = {}
+
+core_callback.register_on_wield_index_change = function(func)
+	core_callback.registered_on_wield_index_change[#core_callback.registered_on_wield_index_change+1]=func
+end
+
+core_callback.reset_hold_time = function(player, control_name)
+	local player_name = player:get_player_name()
+	core_callback.players[player_name].controls[control_name][2] = minetest.get_us_time()/1000000
+end
+
+core_callback.players = {}
+
+minetest.register_on_joinplayer(function(player)
+	core_callback.players[player:get_player_name()] = {
+		controls = {
+			jump = {false},
+			right = {false},
+			left = {false},
+			LMB = {false},
+			RMB = {false},
+			sneak = {false},
+			aux1 = {false},
+			down = {false},
+			up = {false},
+			zoom = {false},
+			dig = {false},
+			place = {false},
+		},
+
+		wield_index = 0
+	}
+end)
+
+minetest.register_on_leaveplayer(function(player)
+	core_callback.players[player:get_player_name()] = nil
+end)
+
+minetest.register_globalstep(function(dtime)
+	for _, player in pairs(minetest.get_connected_players()) do
+		local player_name = player:get_player_name()
+		local player_controls = player:get_player_control()
+		local player_last_controls = core_callback.players[player_name].controls
+		local player_wield_index = player:get_wield_index()
+		local player_last_wield_index = core_callback.players[player_name].wield_index
+
+		for control_name, control_value in pairs(player_controls) do
+			if not player_last_controls then
+				break
+			end
+
+			-- Нажатие
+			if (control_value == true) and (player_last_controls[control_name][1] == false) then
+				for _, func in pairs(core_callback.registered_on_press) do
+					func(player, control_name)
+				end
+				player_last_controls[control_name] = {true, minetest.get_us_time()/1000000}
+
+			-- Удержание
+			elseif (control_value == true) and (player_last_controls[control_name][1] == true) then
+				for _, func in pairs(core_callback.registered_on_hold) do
+					func(player, control_name, minetest.get_us_time()/1000000-player_last_controls[control_name][2], dtime)
+				end
+
+			-- Отпуск
+			elseif (control_value == false) and (player_last_controls[control_name][1] == true) then
+				for _, func in pairs(core_callback.registered_on_release) do
+					func(player, control_name, minetest.get_us_time()/1000000-player_last_controls[control_name][2])
+				end
+				player_last_controls[control_name] = {false}
+			end
+		end
+
+		if player_wield_index ~= player_last_wield_index then
+			for _, func in pairs(core_callback.registered_on_wield_index_change) do
+				func(player, player_wield_index, player_last_wield_index)
+			end
+			player_last_wield_index = player_wield_index
+		end
+		core_callback.players[player_name].controls = player_last_controls
+		core_callback.players[player_name].wield_index = player_last_wield_index
+	end
+end)

--- a/mods/lord/lordlib/core_functions.lua
+++ b/mods/lord/lordlib/core_functions.lua
@@ -104,7 +104,7 @@ minetest.register_on_leaveplayer(function(player)
 end)
 
 -- Вызов каллбэков нажатия клавиши
-function call_press(player, player_last_controls, control_name)
+local function call_press(player, player_last_controls, control_name)
 	-- Время, когда была нажата кнопка
 	local press_time = minetest.get_us_time()/MICROSECONDS
 
@@ -115,7 +115,7 @@ function call_press(player, player_last_controls, control_name)
 end
 
 -- Вызов каллбэков удержания клавиши
-function call_hold(player, player_last_controls, control_name, dtime)
+local function call_hold(player, player_last_controls, control_name, dtime)
 	-- Время, когда была нажата кнопка вычитается из текущего, чтобы получить длительность нажатия
 	local hold_time = minetest.get_us_time()/MICROSECONDS-player_last_controls[control_name][2]
 
@@ -125,7 +125,7 @@ function call_hold(player, player_last_controls, control_name, dtime)
 end
 
 -- Вызов каллбэков отпуска кнопки
-function call_release(player, player_last_controls, control_name)
+local function call_release(player, player_last_controls, control_name)
 	-- Время, сколько была нажата кнопка
 	local release_time = minetest.get_us_time()/MICROSECONDS-player_last_controls[control_name][2]
 

--- a/mods/lord/lordlib/core_functions.lua
+++ b/mods/lord/lordlib/core_functions.lua
@@ -7,8 +7,8 @@ local MICROSECONDS = 1000000
 -- Нажатие
 lord.registered_on_press = {}
 
---- register_on_press(player, control_name)
---- Срабатывает, когда игрок нажимает кнопку
+--- register_on_press(func(player, control_name))
+--- Регистрирует обратный вызов на нажатие кнопки из списка controls
 --- * player - игрок
 --- * control_name - кнопка из списка controls
 lord.register_on_press = function(func)
@@ -18,8 +18,8 @@ end
 -- Отпуск
 lord.registered_on_release = {}
 
---- register_on_release(player, control_name, release_time)
---- Срабатывает, когда игрок отпускает кнопку
+--- register_on_release(func(player, control_name, release_time))
+--- Регистрирует обратный вызов на отпуск кнопки из списка controls
 --- * player - игрок
 --- * control_name - кнопка из списка controls
 --- * release_time - время удержания кнопки до того, как её отпустили
@@ -30,8 +30,8 @@ end
 -- Удержание
 lord.registered_on_hold = {}
 
---- register_on_hold(player, control_name, hold_time, dtime)
---- Срабатывает, когда игрок удерживает какую-то кнопку из списка controls
+--- register_on_hold(func(player, control_name, hold_time, dtime))
+--- Регистрирует обратный вызов на удержании кнопки из списка controls
 --- * player - игрок
 --- * control_name - кнопка из списка controls
 --- * hold_time - время удержания кнопки
@@ -43,8 +43,8 @@ end
 -- Смена индекса предмета в руке
 lord.registered_on_wield_index_change = {}
 
---- register_on_wield_index_change(player, player_wield_index, player_last_wield_index)
---- Вызывается, когда индекс предмета в руке изменяется
+--- register_on_wield_index_change(func(player, player_wield_index, player_last_wield_index))
+--- Регистрирует обратный вызов на смену индекса предмета в руке
 --- * player - игрок
 --- * player_wield_index - текущий индекс предмета в руке
 --- * player_last_wield_index - прошлый индекс предмета в руке
@@ -52,7 +52,10 @@ lord.register_on_wield_index_change = function(func)
 	table.insert(lord.registered_on_wield_index_change, func)
 end
 
--- Сброс времени удержания для кнопки
+--- reset_hold_time(player, control_name)
+--- Сбрасывает время удержания кнопки из списка controls
+--- * player - игрок
+--- * control_name - кнопка из списка controls
 lord.reset_hold_time = function(player, control_name)
 	if not player then return end
 

--- a/mods/lord/lordlib/core_functions.lua
+++ b/mods/lord/lordlib/core_functions.lua
@@ -7,10 +7,13 @@ local MICROSECONDS = 1000000
 -- Нажатие
 lord.registered_on_press = {}
 
---- register_on_press(func(player, control_name))
---- Регистрирует обратный вызов на нажатие кнопки из списка controls
---- * player - игрок
---- * control_name - кнопка из списка controls
+---
+--- Регистрирует обратный вызов на нажатие кнопки из списка controls.
+---
+--- @param func fun(player:Player, control_name:string)
+--- Принимает функцию колбека со след параметрами:
+---  * `player` - игрок
+---  * `control_name` - кнопка из списка controls
 lord.register_on_press = function(func)
 	table.insert(lord.registered_on_press, func)
 end
@@ -18,11 +21,14 @@ end
 -- Отпуск
 lord.registered_on_release = {}
 
---- register_on_release(func(player, control_name, release_time))
+---
 --- Регистрирует обратный вызов на отпуск кнопки из списка controls
---- * player - игрок
---- * control_name - кнопка из списка controls
---- * release_time - время удержания кнопки до того, как её отпустили
+---
+--- @param func fun(player, control_name, release_time)
+--- Принимает функцию колбека со след параметрами:
+---  * `player` - игрок
+---  * `control_name` - кнопка из списка controls
+---  * `release_time` - время удержания кнопки до того, как её отпустили
 lord.register_on_release = function(func)
 	table.insert(lord.registered_on_release, func)
 end
@@ -30,12 +36,15 @@ end
 -- Удержание
 lord.registered_on_hold = {}
 
---- register_on_hold(func(player, control_name, hold_time, dtime))
+---
 --- Регистрирует обратный вызов на удержании кнопки из списка controls
---- * player - игрок
---- * control_name - кнопка из списка controls
---- * hold_time - время удержания кнопки
---- * dtime - время между прошлым и нынешним вызовом
+---
+--- @param func fun(player, control_name, hold_time, dtime)
+--- Принимает функцию колбека со след параметрами:
+---  * `player` - игрок
+---  * `control_name` - кнопка из списка controls
+---  * `hold_time` - время удержания кнопки
+---  * `dtime` - время между прошлым и нынешним вызовом
 lord.register_on_hold = function(func)
 	table.insert(lord.registered_on_hold, func)
 end
@@ -43,19 +52,22 @@ end
 -- Смена индекса предмета в руке
 lord.registered_on_wield_index_change = {}
 
---- register_on_wield_index_change(func(player, player_wield_index, player_last_wield_index))
+---
 --- Регистрирует обратный вызов на смену индекса предмета в руке
---- * player - игрок
---- * player_wield_index - текущий индекс предмета в руке
---- * player_last_wield_index - прошлый индекс предмета в руке
+---
+--- @param func fun(player, player_wield_index, player_last_wield_index)
+--- Принимает функцию колбека со след параметрами:
+---  * `player` - игрок
+---  * `player_wield_index` - текущий индекс предмета в руке
+---  * `player_last_wield_index` - прошлый индекс предмета в руке
 lord.register_on_wield_index_change = function(func)
 	table.insert(lord.registered_on_wield_index_change, func)
 end
 
---- reset_hold_time(player, control_name)
+---
 --- Сбрасывает время удержания кнопки из списка controls
---- * player - игрок
---- * control_name - кнопка из списка controls
+--- @param player ObjRef - игрок
+--- @param control_name string - кнопка из списка controls
 lord.reset_hold_time = function(player, control_name)
 	if not player then return end
 

--- a/mods/lord/lordlib/init.lua
+++ b/mods/lord/lordlib/init.lua
@@ -52,3 +52,4 @@ function minetest.is_creative_enabled(name)
 end
 
 dofile(minetest.get_modpath("lordlib").."/ru_lower_upper.lua") -- string.upper and string.lower russian symbols support
+dofile(minetest.get_modpath(minetest.get_current_modname()) .. "/core_functions.lua")


### PR DESCRIPTION
**Описание PR:**
Добавлены `core_callbacks` из локального и индивидуального проекта `lord2`. В связи с немного иной структурой проекта я вынес `core_function` (основной файл с глобальными функциями для `lord2`, аналог `lordlib`, наверное) в отдельный файл для удобства.

Для чего добавил: Во-первых, это полезная фигня, во-вторых, следующими PR пойдут стягивания с `lord2` механики лука, для обкатывания на сервере (подробности спросите у меня), а так же стягивания механики еды (это далеко в перспективе). Я бы мог добавить её вместе с механикой лука, но решил разделить.

Что умеет: библиотека содержит обратные вызовы для таких случаев, когда игрок нажал клавишу из списка controls, удерживает её, отпускает и меняет предмет в руке.

**Рекомендации к тесту:**

Пока что ничего

**Дополнительная информация:**

---