### PR TITLE
Fix server crash because of breaking a corpse (bones mod)

### DIFF
--- a/mods/lord/bones/init.lua
+++ b/mods/lord/bones/init.lua
@@ -39,6 +39,9 @@ local function register_corpse(race, gender, skin)
 		paramtype2 = "facedir",
 		groups = {dig_immediate=3, corpse = 1},
 		can_dig = function(pos, player)
+			if player == nil then
+				return
+			end
 			local inv = minetest.get_meta(pos):get_inventory()
 			return is_owner(pos, player:get_player_name()) and inv:is_empty("main")
 		end,


### PR DESCRIPTION
Фиксит это:
```
2022-08-30 19:31:06: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod '*builtin*' in callback luaentity_Step(): ...netest-master/bin/../games/lord/mods/lord/bones/init.lua:43: attempt to index local 'player' (a nil value)
2022-08-30 19:31:06: ERROR[Main]: stack traceback:
2022-08-30 19:31:06: ERROR[Main]:       ...netest-master/bin/../games/lord/mods/lord/bones/init.lua:43: in function 'can_dig'
2022-08-30 19:31:06: ERROR[Main]:       /home/user/minetest-master/bin/../builtin/game/item.lua:556: in function 'on_dig'
2022-08-30 19:31:06: ERROR[Main]:       /home/user/minetest-master/bin/../builtin/game/falling.lua:270: in function 'try_place'
2022-08-30 19:31:06: ERROR[Main]:       /home/user/minetest-master/bin/../builtin/game/falling.lua:380: in function </home/user/minetest-master/bin/../builtin/game/falling.lua:295>
```