### PR TITLE
Исправление автоматического срубания дерева

### DIFF
--- a/mods/_lott/lottplants/nodes.lua
+++ b/mods/_lott/lottplants/nodes.lua
@@ -589,9 +589,11 @@ minetest.register_node("lottplants:pinetree", {
 	paramtype2  = "facedir",
 	groups      = { tree = 1, choppy = 3, flammable = 2 },
 	sounds      = default.node_sound_wood_defaults(),
-	on_place    = minetest.rotate_node,
 	on_dig      = function(pos, node, digger)
 		default.dig_tree(pos, node, "lottplants:pinetree", digger, 13, 2, "lottplants:pinetree")
+	end,
+	on_place = function(itemstack, placer, pointed_thing)
+		return default.place_tree(itemstack, placer, pointed_thing, "lottplants:pinetrunk")
 	end,
 })
 
@@ -612,9 +614,11 @@ minetest.register_node("lottplants:firtree", {
 	paramtype2  = "facedir",
 	groups      = { tree = 1, choppy = 3, flammable = 2 },
 	sounds      = default.node_sound_wood_defaults(),
-	on_place    = minetest.rotate_node,
 	on_dig      = function(pos, node, digger)
 		default.dig_tree(pos, node, "lottplants:firtree", digger, 13, 2, "lottplants:firtree")
+	end,
+	on_place = function(itemstack, placer, pointed_thing)
+		return default.place_tree(itemstack, placer, pointed_thing, "lottplants:firtrunk")
 	end,
 })
 
@@ -636,9 +640,11 @@ minetest.register_node("lottplants:birchtree", {
 	paramtype2  = "facedir",
 	groups      = { tree = 1, choppy = 3, flammable = 2 },
 	sounds      = default.node_sound_wood_defaults(),
-	on_place    = minetest.rotate_node,
 	on_dig      = function(pos, node, digger)
 		default.dig_tree(pos, node, "lottplants:birchtree", digger, 12, 3, "lottplants:birchtree")
+	end,
+	on_place = function(itemstack, placer, pointed_thing)
+		return default.place_tree(itemstack, placer, pointed_thing, "lottplants:birchtrunk")
 	end,
 })
 
@@ -659,9 +665,11 @@ minetest.register_node("lottplants:aldertree", {
 	paramtype2  = "facedir",
 	groups      = { tree = 1, choppy = 2, flammable = 2 },
 	sounds      = default.node_sound_wood_defaults(),
-	on_place    = minetest.rotate_node,
 	on_dig      = function(pos, node, digger)
 		default.dig_tree(pos, node, "lottplants:aldertree", digger, 10, 2, "lottplants:aldertree")
+	end,
+	on_place = function(itemstack, placer, pointed_thing)
+		return default.place_tree(itemstack, placer, pointed_thing, "lottplants:aldertrunk")
 	end,
 })
 
@@ -682,9 +690,11 @@ minetest.register_node("lottplants:lebethrontree", {
 	paramtype2  = "facedir",
 	groups      = { tree = 1, choppy = 1, flammable = 2 },
 	sounds      = default.node_sound_wood_defaults(),
-	on_place    = minetest.rotate_node,
 	on_dig      = function(pos, node, digger)
 		default.dig_tree(pos, node, "lottplants:lebethrontree", digger, 10, 2, "lottplants:lebethrontree")
+	end,
+	on_place = function(itemstack, placer, pointed_thing)
+		return default.place_tree(itemstack, placer, pointed_thing, "lottplants:lebethrontrunk")
 	end,
 })
 
@@ -705,9 +715,11 @@ minetest.register_node("lottplants:mallorntree", {
 	paramtype2  = "facedir",
 	groups      = { tree = 1, choppy = 1, flammable = 2 },
 	sounds      = default.node_sound_wood_defaults(),
-	on_place    = minetest.rotate_node,
 	on_dig      = function(pos, node, digger)
 		default.dig_tree(pos, node, "lottplants:mallorntree", digger, 30, 5, "lottplants:mallorntree")
+	end,
+	on_place = function(itemstack, placer, pointed_thing)
+		return default.place_tree(itemstack, placer, pointed_thing, "lottplants:mallorntrunk")
 	end,
 })
 
@@ -746,9 +758,11 @@ minetest.register_node("lottplants:mallorntree_young", {
 	paramtype2  = "facedir",
 	groups      = { tree = 1, choppy = 1, flammable = 2, fuel = 1 },
 	sounds      = default.node_sound_wood_defaults(),
-	on_place    = minetest.rotate_node,
 	on_dig      = function(pos, node, digger)
 		default.dig_tree(pos, node, "lottplants:mallorntree_young", digger, 10, 1, "lottplants:mallorntree_young")
+	end,
+	on_place = function(itemstack, placer, pointed_thing)
+		return default.place_tree(itemstack, placer, pointed_thing, "lottplants:mallorntrunk_young")
 	end,
 })
 

--- a/mods/lord/_overwrites/MTG/default/init.lua
+++ b/mods/lord/_overwrites/MTG/default/init.lua
@@ -531,54 +531,37 @@ minetest.override_item("default:jungletree", {
 
 -- Падение ствола деревьев вниз при ломании
 
-local falling_trees = minetest.settings:get_bool("falling_trees")
+function default.dig_tree(pos, node, name, digger, height, radius, drop)
+	minetest.node_dig(pos, node, digger)
 
-if not falling_trees then
-	if minetest.is_singleplayer() then
-		falling_trees = false
-	else
-		falling_trees = true
+	if minetest.is_protected(pos, digger:get_player_name()) then
+		return
 	end
-end
 
-if falling_trees == true then
-	function default.dig_tree(pos, node, name, digger, height, radius, drop)
-		minetest.node_dig(pos, node, digger)
-
-		if minetest.is_protected(pos, digger:get_player_name()) then
-			return
-		end
-
-		local base_y = pos.y
-		for i = 1, (height + 5) do
-			pos.y        = base_y + i
-			local node_i = minetest.get_node(pos)
-			if node_i.name ~= name or i == (height + 5) then
-				minetest.remove_node({ x = pos.x, y = pos.y - 1, z = pos.z })
-				for k = -radius, radius do
-					for l = -radius, radius do
-						for j = 0, 1 do
-							local tree_bellow = minetest.get_node({ x = pos.x + k, y = pos.y - 1, z = pos.z + l })
-							if tree_bellow.name ~= name then
-								local pos1 = { x = pos.x + k, y = pos.y + j, z = pos.z + l }
-								if minetest.get_node(pos1).name == name then
-									minetest.spawn_item(pos1, drop)
-									minetest.remove_node(pos1)
-								end
+	local base_y = pos.y
+	for i = 1, (height + 5) do
+		pos.y        = base_y + i
+		local node_i = minetest.get_node(pos)
+		if node_i.name ~= name or i == (height + 5) then
+			minetest.remove_node({ x = pos.x, y = pos.y - 1, z = pos.z })
+			for k = -radius, radius do
+				for l = -radius, radius do
+					for j = 0, 1 do
+						local tree_bellow = minetest.get_node({ x = pos.x + k, y = pos.y - 1, z = pos.z + l })
+						if tree_bellow.name ~= name then
+							local pos1 = { x = pos.x + k, y = pos.y + j, z = pos.z + l }
+							if minetest.get_node(pos1).name == name then
+								minetest.spawn_item(pos1, drop)
+								minetest.remove_node(pos1)
 							end
 						end
 					end
 				end
-				return
-			elseif node_i.name == name then
-				minetest.set_node({ x = pos.x, y = pos.y - 1, z = pos.z }, { name = name })
 			end
+			return
+		elseif node_i.name == name then
+			minetest.set_node({ x = pos.x, y = pos.y - 1, z = pos.z }, { name = name })
 		end
-	end
-else
-	function default.dig_tree(pos, node, name, digger, height, radius, drop)
-		minetest.node_dig(pos, node, digger)
-		return nil
 	end
 end
 

--- a/mods/lord/_overwrites/MTG/default/init.lua
+++ b/mods/lord/_overwrites/MTG/default/init.lua
@@ -517,11 +517,17 @@ minetest.override_item("default:tree", {
 	on_dig = function(pos, node, digger)
 		default.dig_tree(pos, node, "default:tree", digger, 20, 2, "default:tree")
 	end,
+	on_place = function(itemstack, placer, pointed_thing)
+		return default.place_tree(itemstack, placer, pointed_thing, "default:tree_trunk")
+	end,
 })
 
 minetest.override_item("default:jungletree", {
 	on_dig = function(pos, node, digger)
 		default.dig_tree(pos, node, "default:jungletree", digger, 20, 2, "default:jungletree")
+	end,
+	on_place = function(itemstack, placer, pointed_thing)
+		return default.place_tree(itemstack, placer, pointed_thing, "default:jungletree_trunk")
 	end,
 })
 
@@ -529,8 +535,18 @@ minetest.override_item("default:jungletree", {
 -- default/functions.lua
 
 
--- Падение ствола деревьев вниз при ломании
+--- Устанавливает trunk вместо tree (обработчик для on_place в tree).
+---@param itemstack ItemStack @stack в руках игрока (tree)
+---@param placer Player @объект игрока
+---@param pointed_thing pointed_thing @объект направления
+---@param trunk_name string @название соответствующего дереву (tree) блока trunk
+---@return ItemStack @обновлённый stack в руках игрока (tree)
+function default.place_tree(itemstack, placer, pointed_thing, trunk_name)
+	minetest.rotate_node(ItemStack(trunk_name), placer, pointed_thing)
+	return itemstack:take_item()
+end
 
+-- Падение ствола деревьев вниз при ломании
 function default.dig_tree(pos, node, name, digger, height, radius, drop)
 	minetest.node_dig(pos, node, digger)
 


### PR DESCRIPTION
Исправлен treecapitator (с обратной совместимостью), а также убран опциональность параметра, отвечающего за него. Теперь деревья падают при рубке всегда, в том числе и в локальном мире.

Тестировать установку блоков, рубку деревьев и установленных игроком стволов деревьев. А также протестировать всё то же самое в привате (обязательно!).
