### PR TITLE
fix books capabilities for correct tooltips. fixes #800

### DIFF
--- a/mods/_lott/lottinventory/brewing.lua
+++ b/mods/_lott/lottinventory/brewing.lua
@@ -73,15 +73,6 @@ minetest.register_tool("lottinventory:brewing_book",{
     wield_scale = {x=1,y=1,z=1},
     stack_max = 1,
     groups = {cook_crafts=1, book=1, paper=1},
-    tool_capabilities = {
-        full_punch_interval = 1.0,
-        max_drop_level=0,
-        groupcaps={
-            fleshy={times={[2]=0.80, [3]=0.40}, uses=20, maxlevel=1},
-            snappy={times={[2]=0.80, [3]=0.40}, uses=20, maxlevel=1},
-            choppy={times={[3]=0.90}, uses=20, maxlevel=0}
-        }
-    },
     on_use = function(itemstack, player, pointed_thing)
           inventory_plus.set_inventory_formspec(player, get_formspec(player,"brews"))
           return itemstack; -- nothing consumed, nothing changed

--- a/mods/_lott/lottinventory/cooking.lua
+++ b/mods/_lott/lottinventory/cooking.lua
@@ -240,15 +240,6 @@ minetest.register_tool("lottinventory:cooking_book", {
 	wield_image       = "",
 	wield_scale       = { x = 1, y = 1, z = 1 },
 	stack_max         = 1,
-	tool_capabilities = {
-		full_punch_interval = 1.0,
-		max_drop_level      = 0,
-		groupcaps           = {
-			fleshy = { times = { [2] = 0.80, [3] = 0.40 }, uses = 20, maxlevel = 1 },
-			snappy = { times = { [2] = 0.80, [3] = 0.40 }, uses = 20, maxlevel = 1 },
-			choppy = { times = { [3] = 0.90 }, uses = 20, maxlevel = 0 }
-		}
-	},
 	on_use            = function(itemstack, player, pointed_thing)
 		local pn = player:get_player_name();
 		if zcc.users[pn] == nil then

--- a/mods/_lott/lottinventory/forbidden.lua
+++ b/mods/_lott/lottinventory/forbidden.lua
@@ -223,15 +223,6 @@ minetest.register_tool("lottinventory:forbidden_crafts_book",{
     wield_image = "",
     wield_scale = {x=1,y=1,z=1},
     stack_max = 1,
-    tool_capabilities = {
-        full_punch_interval = 1.0,
-        max_drop_level=0,
-        groupcaps={
-            fleshy={times={[2]=0.80, [3]=0.40}, uses=20, maxlevel=1},
-            snappy={times={[2]=0.80, [3]=0.40}, uses=20, maxlevel=1},
-            choppy={times={[3]=0.90}, uses=20, maxlevel=0}
-        }
-    },
     groups = {armor_crafts=1, book=1, paper=1},
     on_use = function(itemstack, player, pointed_thing)
 		local pn = player:get_player_name();

--- a/mods/_lott/lottinventory/master.lua
+++ b/mods/_lott/lottinventory/master.lua
@@ -274,15 +274,6 @@ minetest.register_tool("lottinventory:master_book",{
     wield_image = "",
     wield_scale = {x=1,y=1,z=1},
     stack_max = 1,
-    tool_capabilities = {
-        full_punch_interval = 1.0,
-        max_drop_level=0,
-        groupcaps={
-            fleshy={times={[2]=0.80, [3]=0.40}, uses=20, maxlevel=1},
-            snappy={times={[2]=0.80, [3]=0.40}, uses=20, maxlevel=1},
-            choppy={times={[3]=0.90}, uses=20, maxlevel=0}
-        }
-    },
     groups = {forbidden=1, book=1, paper=1},
     on_use = function(itemstack, player, pointed_thing)
 		local pn = player:get_player_name();

--- a/mods/_lott/lottinventory/potions.lua
+++ b/mods/_lott/lottinventory/potions.lua
@@ -448,15 +448,6 @@ minetest.register_tool("lottinventory:potions_book",{
     wield_scale = {x=1,y=1,z=1},
     stack_max = 1,
     groups = {cook_crafts=1, book=1, paper=1},
-    tool_capabilities = {
-        full_punch_interval = 1.0,
-        max_drop_level=0,
-        groupcaps={
-            fleshy={times={[2]=0.80, [3]=0.40}, uses=20, maxlevel=1},
-            snappy={times={[2]=0.80, [3]=0.40}, uses=20, maxlevel=1},
-            choppy={times={[3]=0.90}, uses=20, maxlevel=0}
-        }
-    },
     on_use = function(itemstack, player, pointed_thing)
           inventory_plus.set_inventory_formspec(player, get_formspec(player,"potions"))
           return itemstack; -- nothing consumed, nothing changed

--- a/mods/_lott/lottinventory/protection.lua
+++ b/mods/_lott/lottinventory/protection.lua
@@ -232,15 +232,6 @@ minetest.register_tool("lottinventory:protection_book",{
     wield_image = "",
     wield_scale = {x=1,y=1,z=1},
     stack_max = 1,
-    tool_capabilities = {
-        full_punch_interval = 1.0,
-        max_drop_level=0,
-        groupcaps={
-            fleshy={times={[2]=0.80, [3]=0.40}, uses=20, maxlevel=1},
-            snappy={times={[2]=0.80, [3]=0.40}, uses=20, maxlevel=1},
-            choppy={times={[3]=0.90}, uses=20, maxlevel=0}
-        }
-    },
     on_use = function(itemstack, player, pointed_thing)
 		local pn = player:get_player_name();
 		if zpc.users[pn] == nil then zpc.users[pn] = {current_item = "", alt = 1, page = 0, history={index=0,list={}}} end

--- a/mods/_lott/lottinventory/zcg.lua
+++ b/mods/_lott/lottinventory/zcg.lua
@@ -286,15 +286,6 @@ minetest.register_tool("lottinventory:crafts_book",{
     wield_image = "",
     wield_scale = {x=1,y=1,z=1},
     stack_max = 1,
-    tool_capabilities = {
-        full_punch_interval = 1.0,
-        max_drop_level=0,
-        groupcaps={
-            fleshy={times={[2]=0.80, [3]=0.40}, uses=20, maxlevel=1},
-            snappy={times={[2]=0.80, [3]=0.40}, uses=20, maxlevel=1},
-            choppy={times={[3]=0.90}, uses=20, maxlevel=0}
-        }
-    },
     on_use = function(itemstack, player, pointed_thing)
 		local pn = player:get_player_name();
 		if zcg.users[pn] == nil then zcg.users[pn] = {current_item = "", alt = 1, page = 0, history={index=0,list={}}} end


### PR DESCRIPTION
**Описание PR:**

Исправление параметров книг для правильного отображения всплывашек (tooltips).
См. #800 

**Рекомендации к тесту:**

 - проверить, что описаний параметров добычи нет
 - попробовать книгами "подобывать" (навести на и открыть) камень, траву, руду, дерево -- убедиться, что происходит только открытие, а блоки не добываются / не ломаются, даже _**"строительные леса"**_
