### PR TITLE
Replace deprecated `vel` and `acc` attributes in bees. Fixes #828

### DIFF
--- a/mods/lord/bees/init.lua
+++ b/mods/lord/bees/init.lua
@@ -103,8 +103,8 @@ local S = minetest.get_translator("bees")
         --wax flying all over the place
         minetest.add_particle({
           pos = {x=pos.x, y=pos.y, z=pos.z},
-          vel = {x=math.random(-4,4),y=math.random(8),z=math.random(-4,4)},
-          acc = {x=0,y=-6,z=0},
+          velocity = {x=math.random(-4,4),y=math.random(8),z=math.random(-4,4)},
+          acceleration = {x=0,y=-6,z=0},
           expirationtime = 2,
           size = math.random(1,3),
           collisiondetection = false,
@@ -218,8 +218,8 @@ local S = minetest.get_translator("bees")
       if inv:contains_item('queen', 'mobs:bee') then
         minetest.add_particle({
             pos = {x=pos.x, y=pos.y, z=pos.z},
-          vel = {x=(math.random()-0.5)*5,y=(math.random()-0.5)*5,z=(math.random()-0.5)*5},
-          acc = {x=math.random()-0.5,y=math.random()-0.5,z=math.random()-0.5},
+          velocity = {x=(math.random()-0.5)*5,y=(math.random()-0.5)*5,z=(math.random()-0.5)*5},
+          acceleration = {x=math.random()-0.5,y=math.random()-0.5,z=math.random()-0.5},
           expirationtime = math.random(2.5),
           size = math.random(3),
           collisiondetection = true,
@@ -416,8 +416,8 @@ local S = minetest.get_translator("bees")
           for i=1,6 do
             minetest.add_particle({
               pos = {x=pos.x+math.random()-0.5, y=pos.y, z=pos.z+math.random()-0.5},
-              vel = {x=0,y=0.5+math.random(),z=0},
-              acc = {x=0,y=0,z=0},
+              velocity = {x=0,y=0.5+math.random(),z=0},
+              acceleration = {x=0,y=0,z=0},
               expirationtime = 2+math.random(2.5),
               size = math.random(3),
               collisiondetection = false,


### PR DESCRIPTION
#828 