### PR TITLE
Fixes #853. Define use_texture_alpha for protector sign (set to clip)

### DIFF
--- a/mods/_various/protector_lott/init.lua
+++ b/mods/_various/protector_lott/init.lua
@@ -266,6 +266,7 @@ minetest.register_node("protector_lott:protect2", {
 	drawtype = "nodebox",
 	sunlight_propagates = true,
 	walkable = true,
+	use_texture_alpha = "clip",
 	node_box = {
 		type = "wallmounted",
 		wall_top    = {-0.375, 0.4375, -0.5, 0.375, 0.5, 0.5},


### PR DESCRIPTION
Add use_texture_alpha = "clip" to the protector_lott:protect2 registration

Fixes #853.
