### PR TITLE
Удаление хардкорных переводов в lottachievements (fix 1025)

### DIFF
--- a/mods/_lott/lottachievements/init.lua
+++ b/mods/_lott/lottachievements/init.lua
@@ -737,7 +737,7 @@ lottachievements.register_achievement("magic", {
 			end
 			minetest.chat_send_player(
 				grant_name,
-				minetest.colorize("purple", "Теперь вы можете совершать перемещения с помощью палантиров")
+				minetest.colorize("purple", SL("You can now move with palantiri"))
 			)
 			minetest.set_player_privs(grant_name, privs)
 		end,

--- a/mods/_lott/lottachievements/init.lua
+++ b/mods/_lott/lottachievements/init.lua
@@ -737,7 +737,7 @@ lottachievements.register_achievement("magic", {
 			end
 			minetest.chat_send_player(
 				grant_name,
-				minetest.colorize("purple", SL("You can now move with palantiri"))
+				minetest.colorize("purple", SL("You can now travel with palantiri"))
 			)
 			minetest.set_player_privs(grant_name, privs)
 		end,

--- a/mods/_lott/lottachievements/locale/ru.txt
+++ b/mods/_lott/lottachievements/locale/ru.txt
@@ -145,6 +145,7 @@ Polisher = Полировщик
 Polish a gem = Отполируйте драгоценный камень
 Ring Smith = Кольцо Кузнеца
 Forge a ring of power = Выковать кольцо всевластья
+You can now move with palantiri=Теперь вы можете совершать перемещения с помощью палантиров
 
 ### api.lua ###
 Secret Achievement Unlocked: = Секретное достижение разблокировано:

--- a/mods/_lott/lottachievements/locale/ru.txt
+++ b/mods/_lott/lottachievements/locale/ru.txt
@@ -145,7 +145,7 @@ Polisher = Полировщик
 Polish a gem = Отполируйте драгоценный камень
 Ring Smith = Кольцо Кузнеца
 Forge a ring of power = Выковать кольцо всевластья
-You can now move with palantiri=Теперь вы можете совершать перемещения с помощью палантиров
+You can now travel with palantiri=Теперь вы можете совершать перемещения с помощью палантиров
 
 ### api.lua ###
 Secret Achievement Unlocked: = Секретное достижение разблокировано:

--- a/mods/_lott/lottachievements/triggers.lua
+++ b/mods/_lott/lottachievements/triggers.lua
@@ -35,7 +35,7 @@ lottachievements.register_trigger("dig", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("Mine @1/@2", itemcount, tmp.target),
+			label = S("Mined @1/@2", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)
@@ -72,7 +72,7 @@ lottachievements.register_trigger("place", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("Place @1/@2", itemcount, tmp.target),
+			label = S("Placed @1/@2", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)
@@ -109,7 +109,7 @@ lottachievements.register_trigger("eat", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("Eat @1/@2", itemcount, tmp.target),
+			label = S("Eaten @1/@2", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)
@@ -162,7 +162,7 @@ lottachievements.register_trigger("chat", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("Write chat messages @1/@2", itemcount, tmp.target),
+			label = S("Chat messages written @1/@2", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)
@@ -184,7 +184,7 @@ lottachievements.register_trigger("join", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("Join the game @1/@2", itemcount, tmp.target),
+			label = S("Game joins @1/@2", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)
@@ -215,7 +215,7 @@ lottachievements.register_trigger("craft", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("Craft @1/@2", itemcount, tmp.target),
+			label = S("Crafted @1/@2", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)
@@ -272,7 +272,7 @@ lottachievements.register_trigger("kill", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("Kill @1/@2", itemcount, tmp.target),
+			label = S("Killed @1/@2", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)

--- a/mods/_lott/lottachievements/triggers.lua
+++ b/mods/_lott/lottachievements/triggers.lua
@@ -35,7 +35,7 @@ lottachievements.register_trigger("dig", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("Добыто @1/@2", itemcount, tmp.target),
+			label = S("Mine @1/@2", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)
@@ -72,7 +72,7 @@ lottachievements.register_trigger("place", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("Установленно @1/@2", itemcount, tmp.target),
+			label = S("Place @1/@2", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)
@@ -109,7 +109,7 @@ lottachievements.register_trigger("eat", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("Съедено @1/@2", itemcount, tmp.target),
+			label = S("Eat @1/@2", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)
@@ -140,7 +140,7 @@ lottachievements.register_trigger("death", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("@1/@2 смертей", itemcount, tmp.target),
+			label = S("@1/@2 deaths", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)
@@ -162,7 +162,7 @@ lottachievements.register_trigger("chat", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("Написано сообщений @1/@2", itemcount, tmp.target),
+			label = S("Write chat messages @1/@2", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)
@@ -184,7 +184,7 @@ lottachievements.register_trigger("join", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("Заходов на сервер @1/@2", itemcount, tmp.target),
+			label = S("Join the game @1/@2", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)
@@ -215,7 +215,7 @@ lottachievements.register_trigger("craft", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("Создано @1/@2", itemcount, tmp.target),
+			label = S("Craft @1/@2", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)
@@ -272,7 +272,7 @@ lottachievements.register_trigger("kill", function(def)
 		end
 		return {
 			perc = itemcount / tmp.target,
-			label = S("Убито @1/@2", itemcount, tmp.target),
+			label = S("Kill @1/@2", itemcount, tmp.target),
 		}
 	end
 	def.getDefaultDescription = function(self)


### PR DESCRIPTION
fix #1025
Удалил русскоязычные слова из кода. Реплики из init.lua перенес на локализацию. Реплики из triggers.lua без переводов (в игре отображается на английском) из-за сложности добавление локализации (нужно разбираться с функциями в intlib)