### PR TITLE
Исправление целевой ноды достижения "Тормоз!"

### DIFF
--- a/mods/_lott/lottachievements/init.lua
+++ b/mods/_lott/lottachievements/init.lua
@@ -485,7 +485,7 @@ lottachievements.register_achievement("brake", {
 	id          = 36,
 	trigger     = {
 		type   = "place",
-		node   = "carts:stopping_rail",
+		node   = "carts:brakerail",
 		target = 40,
 	}
 })


### PR DESCRIPTION
fix #1033

Тестирование: проверить возможность получить достижение "Тормоз!" (установить 40 тормозящих рельс)