### PR TITLE
Упрощение крафтов воскового блока и блока сот

### DIFF
--- a/mods/lord/bees/init.lua
+++ b/mods/lord/bees/init.lua
@@ -334,7 +334,7 @@ local S = minetest.get_translator("bees")
 
   minetest.register_craft({
     type = 'shapeless',
-    output = 'bees:honey_comb 9',
+    output = 'bees:honey_comb 4',
     recipe = {'bees:honey_comb_block'},
   })
 
@@ -348,7 +348,7 @@ local S = minetest.get_translator("bees")
 
   minetest.register_craft({
     type = 'shapeless',
-    output = 'bees:wax 9',
+    output = 'bees:wax 4',
     recipe = {'bees:wax_block'},
   })
 

--- a/mods/lord/bees/init.lua
+++ b/mods/lord/bees/init.lua
@@ -327,9 +327,8 @@ local S = minetest.get_translator("bees")
   minetest.register_craft({
     output = 'bees:honey_comb_block',
     recipe = {
-      {'bees:honey_comb','bees:honey_comb','bees:honey_comb'},
-      {'bees:honey_comb','bees:honey_comb','bees:honey_comb'},
-      {'bees:honey_comb','bees:honey_comb','bees:honey_comb'},
+      {'bees:honey_comb','bees:honey_comb'},
+      {'bees:honey_comb','bees:honey_comb'},
     }
   })
 
@@ -342,9 +341,8 @@ local S = minetest.get_translator("bees")
   minetest.register_craft({
     output = 'bees:wax_block',
     recipe = {
-      {'bees:wax','bees:wax','bees:wax'},
-      {'bees:wax','bees:wax','bees:wax'},
-      {'bees:wax','bees:wax','bees:wax'},
+      {'bees:wax','bees:wax'},
+      {'bees:wax','bees:wax'},
     }
   })
 


### PR DESCRIPTION
Причина: трудное получение компонентов (воск получить ещё возможно, а вот соты добываются из диких ульев)