### PR TITLE
Упрощение крафта известняка

### DIFF
--- a/mods/lord/lottores/init.lua
+++ b/mods/lord/lottores/init.lua
@@ -912,14 +912,13 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'lottores:limestone',
 	recipe = {
-		{'lottores:limestone_lump', 'lottores:limestone_lump', 'lottores:limestone_lump'},
-		{'lottores:limestone_lump', 'lottores:limestone_lump', 'lottores:limestone_lump'},
-		{'lottores:limestone_lump', 'lottores:limestone_lump', 'lottores:limestone_lump'},
+		{'lottores:limestone_lump', 'lottores:limestone_lump',},
+		{'lottores:limestone_lump', 'lottores:limestone_lump'},
 	}
 })
 
 minetest.register_craft({
-	output = 'lottores:limestone_lump 9',
+	output = 'lottores:limestone_lump 4',
 	recipe = {
 		{'lottores:limestone'},
 	}


### PR DESCRIPTION
Причина: слишком дорогое производство мрамора из-за соотношения добываемого к готовому 1 к 9