### PR TITLE
Добавление поля catch_up в регистрацию ABM растений

### DIFF
--- a/mods/lord/lottfarming/init.lua
+++ b/mods/lord/lottfarming/init.lua
@@ -70,6 +70,7 @@ function farming:add_plant(full_grown, names, interval, chance, param2)
 		nodenames = names,
 		interval = interval,
 		chance = chance,
+		catch_up = true,
 		action = function(pos, node)
 			pos.y = pos.y-1
 			if minetest.get_node(pos).name ~= "farming:soil_wet" then


### PR DESCRIPTION
fix #321
Лаконичное решение, не требующее особых переработок:
```catch_up = true,
If true, catch-up behavior is enabled: The `chance` value is
temporarily reduced when returning to an area to simulate time lost
by the area being unattended. Note that the `chance` value can often
be reduced to 1.```