### PR TITLE
Добавление белого списка для прилавков

### DIFF
--- a/mods/lord/Tools/lord_money/locale/lord_money.ru.tr
+++ b/mods/lord/Tools/lord_money/locale/lord_money.ru.tr
@@ -27,3 +27,5 @@ Exchanged!=Обмен прошёл успешно!
 Endless Store=Нескончаемый
 Exchange shop is not working, please contact the seller=Прилавок не работает, свяжитесь с продавцом
 This item must be wear-free: =Этот предмет должен быть новым: 
+You are not the owner of this shop!=Вы не владелец этого прилавка!
+Add member=Добавить игрока

--- a/mods/lord/Tools/lord_money/shop.lua
+++ b/mods/lord/Tools/lord_money/shop.lua
@@ -381,7 +381,7 @@ minetest.register_on_player_receive_fields(
 		end
 
 		for field, value in pairs(fields) do
-			if string.find(field, "delete_member_") then
+			if string.find(field, "delete_member_") and ( name == meta:get_string("owner") or minetest.get_player_privs(name).server )then
 				local member = string.gsub(field, "delete_member_", "")
 				remove_member(meta, member)
 				minetest.show_formspec(name,"lord_money:shop_formspec",

--- a/mods/lord/Tools/lord_money/shop.lua
+++ b/mods/lord/Tools/lord_money/shop.lua
@@ -98,14 +98,14 @@ shop.formspec = {
 	end,
 
 	configurator = function(pos, admin, is_endless)
-		local formspec = shop.formspec.configurator_base(pos, admin, is_edless)
+		local formspec = shop.formspec.configurator_base(pos, admin, is_endless)
 
 		formspec = formspec.."button[7.15,4.35;0.75,1;whitelist_on;>]"
 		return formspec
 	end,
 
 	configurator_whitelist = function(pos, admin, is_endless, members_list)
-		local formspec = shop.formspec.configurator_base(pos, admin, is_edless)
+		local formspec = shop.formspec.configurator_base(pos, admin, is_endless)
 
 		formspec:gsub("size[8,9]", "size[10,9]")
 		formspec = formspec.."button[7.15,4.35;0.75,1;whitelist_off;<]"..
@@ -132,7 +132,7 @@ shop.player_has_access = function(player, shop_pos)
 	local owner_name = meta:get_string("owner")
 	local members = meta:get_string("members")
 	local player_name = player:get_player_name()
-	local is_admin = minetest.get_player_privs(player_name).server 
+	local is_admin = minetest.get_player_privs(player_name).server
 	return player_name == owner_name or is_admin or string.find(" "..members.." ", " "..player_name.." ") , is_admin
 end
 
@@ -336,7 +336,7 @@ minetest.register_on_player_receive_fields(
 		elseif fields.whitelist_off then -- Скрыть белый список
 			minetest.show_formspec(name,"lord_money:shop_formspec",
 				shop.formspec.configurator(minetest.string_to_pos(pos), is_admin, is_endless))
-		
+
 		elseif fields.add_member then -- Добавить игрока в список
 			add_member(meta, fields.add_member)
 

--- a/mods/lord/Tools/lord_money/shop.lua
+++ b/mods/lord/Tools/lord_money/shop.lua
@@ -381,7 +381,9 @@ minetest.register_on_player_receive_fields(
 		end
 
 		for field, value in pairs(fields) do
-			if string.find(field, "delete_member_") and ( name == meta:get_string("owner") or minetest.get_player_privs(name).server )then
+			if string.find(field, "delete_member_") and ( 
+				name == meta:get_string("owner") or minetest.get_player_privs(name).server
+			) then
 				local member = string.gsub(field, "delete_member_", "")
 				remove_member(meta, member)
 				minetest.show_formspec(name,"lord_money:shop_formspec",

--- a/mods/lord/Tools/lord_money/shop.lua
+++ b/mods/lord/Tools/lord_money/shop.lua
@@ -110,6 +110,7 @@ shop.formspec = {
 		formspec:gsub("size[8,9]", "size[10,9]")
 		formspec = formspec.."button[7.15,4.35;0.75,1;whitelist_off;<]"..
 		"field[8.5,0.5;2.5,.5;add_member;"..S("Add member")..";]"..
+		"field_close_on_enter[add_member;false]"..
 		"scroll_container[10.25,1.5;4,9;members;vertical;]"
 
 		for i, member in ipairs(members_list) do
@@ -339,6 +340,8 @@ minetest.register_on_player_receive_fields(
 
 		elseif fields.add_member then -- Добавить игрока в список
 			add_member(meta, fields.add_member)
+			minetest.show_formspec(name,"lord_money:shop_formspec",
+					shop.formspec.configurator_whitelist(minetest.string_to_pos(pos), is_admin, is_endless,  get_members_list(meta)))
 
 		elseif fields.quit then -- выход с формы, возвращаем остатки игроку в инвентарь
 			for _,list in pairs({"customer_gives", "customer_gets"}) do

--- a/mods/lord/Tools/lord_money/shop.lua
+++ b/mods/lord/Tools/lord_money/shop.lua
@@ -381,7 +381,7 @@ minetest.register_on_player_receive_fields(
 		end
 
 		for field, value in pairs(fields) do
-			if string.find(field, "delete_member_") and ( 
+			if string.find(field, "delete_member_") and (
 				name == meta:get_string("owner") or minetest.get_player_privs(name).server
 			) then
 				local member = string.gsub(field, "delete_member_", "")

--- a/mods/lord/Tools/lord_money/shop.lua
+++ b/mods/lord/Tools/lord_money/shop.lua
@@ -3,6 +3,11 @@
 -- Load support for MT game translation
 local S = minetest.get_translator("lord_money")
 
+--- @param listname string
+--- @param stack ItemStack
+--- @param player ObjectRef
+---
+--- @return bool
 local function has_wear(listname, stack, player)
 	if listname == "owner_gives" or listname == "stock"  then --проверка износа в "Предложение" и "Склад"
 		if stack:get_wear() > 0 then
@@ -13,11 +18,16 @@ local function has_wear(listname, stack, player)
 	return false
 end
 
+--- @param meta NodeMetaRef
+---
+--- @return table
 local function get_members_list(meta)
 	local list = meta:get_string("members")
 	return list:split(" ")
 end
 
+--- @param meta NodeMetaRef
+--- @param name string
 local function add_member(meta, name)
 	local members = meta:get_string("members")
 	if not string.find(" "..members.." ", " "..name.." ") then -- Проверка, не внесено ли имя в список
@@ -26,6 +36,8 @@ local function add_member(meta, name)
 	end
 end
 
+--- @param meta NodeMetaRef
+--- @param name string
 local function remove_member(meta, name)
 	local list = get_members_list(meta)
 	print(dump(list))
@@ -328,7 +340,8 @@ minetest.register_on_player_receive_fields(
 		elseif fields.whitelist_on then -- Показать белый список
 			if name == meta:get_string("owner") or minetest.get_player_privs(name).server then
 				minetest.show_formspec(name,"lord_money:shop_formspec",
-					shop.formspec.configurator_whitelist(minetest.string_to_pos(pos), is_admin, is_endless,  get_members_list(meta)))
+					shop.formspec.configurator_whitelist(minetest.string_to_pos(pos), is_admin, is_endless,  get_members_list(meta))
+				)
 			else
 				minetest.chat_send_player(name, S("You are not the owner of this shop!"))
 			end
@@ -336,12 +349,18 @@ minetest.register_on_player_receive_fields(
 
 		elseif fields.whitelist_off then -- Скрыть белый список
 			minetest.show_formspec(name,"lord_money:shop_formspec",
-				shop.formspec.configurator(minetest.string_to_pos(pos), is_admin, is_endless))
+				shop.formspec.configurator(minetest.string_to_pos(pos), is_admin, is_endless)
+			)
 
 		elseif fields.add_member then -- Добавить игрока в список
-			add_member(meta, fields.add_member)
-			minetest.show_formspec(name,"lord_money:shop_formspec",
-					shop.formspec.configurator_whitelist(minetest.string_to_pos(pos), is_admin, is_endless,  get_members_list(meta)))
+			if name == meta:get_string("owner") or minetest.get_player_privs(name).server then
+				add_member(meta, fields.add_member)
+				minetest.show_formspec(name,"lord_money:shop_formspec",
+					shop.formspec.configurator_whitelist(minetest.string_to_pos(pos), is_admin, is_endless,  get_members_list(meta))
+				)
+			else
+				minetest.chat_send_player(name, S("You are not the owner of this shop!"))
+			end
 
 		elseif fields.quit then -- выход с формы, возвращаем остатки игроку в инвентарь
 			for _,list in pairs({"customer_gives", "customer_gets"}) do
@@ -366,7 +385,8 @@ minetest.register_on_player_receive_fields(
 				local member = string.gsub(field, "delete_member_", "")
 				remove_member(meta, member)
 				minetest.show_formspec(name,"lord_money:shop_formspec",
-					shop.formspec.configurator_whitelist(minetest.string_to_pos(pos), is_admin, is_endless,  get_members_list(meta)))
+					shop.formspec.configurator_whitelist(minetest.string_to_pos(pos), is_admin, is_endless,  get_members_list(meta))
+				)
 			end
 		end
 	end


### PR DESCRIPTION
**Описание PR:**

Добавление в GUI прилавка кнопки, которая открывает новый раздел со списком совладельцев. Совладельцы имеют доступ к складу прилавка, но не могут открыть список совладельцев. Так же список совладельцев может открыть администратор.
![screenshot_20240415_204733](https://github.com/lord-server/lord/assets/82447582/510ff3be-7659-4e3c-b098-97448cce32fb)
![screenshot_20240415_204735](https://github.com/lord-server/lord/assets/82447582/7c01a31b-2fe6-4aa9-a667-1abc0e55609f)


**Рекомендации к тесту:**

- Работоспособность прилавка как таковую в том числе бесконечных прилавков (не сломал ли я чего)
- Работоспособность белого списка (добавляются ли в него совладельцы, имеют ли они доступ к складу и не имеют ли они доступа к списку)

closes #154 