### PR TITLE
[lord_bows] Частичное исправление луков

### DIFF
--- a/mods/lord/_experimental/lord_bows/entities_projectiles.lua
+++ b/mods/lord/_experimental/lord_bows/entities_projectiles.lua
@@ -105,9 +105,9 @@ projectiles.register_projectile_arrow_type = function(name, item, def)
 		-- Таймер жизни:
 		life_timer           = 10,
 		timer_is_start       = false,
-		
+
 		-- Стрелок
-		shooter,
+		shooter              = {},
 
 		-- Зависящие от def параметры
 		textures             = def.textures,

--- a/mods/lord/_experimental/lord_bows/entities_projectiles.lua
+++ b/mods/lord/_experimental/lord_bows/entities_projectiles.lua
@@ -45,16 +45,16 @@ local function hit_handling(entity, target, name, def)
 end
 
 -- Обработка столкновения
-local function collision_handling(entity, moveresult, name, def)
-local vel = entity.object:get_velocity()
-entity.object:set_velocity({x = vel.x/15, y = vel.y/15, z = vel.z/15})
+local function collision_handling(entity, move_result, name, def)
+	local vel = entity.object:get_velocity()
+	entity.object:set_velocity({x = vel.x/15, y = vel.y/15, z = vel.z/15})
 
-	if not moveresult.collisions[1] then
+	if not move_result.collisions[1] then
 		return
 	end
 
-	if moveresult.collisions[1].type == "node" then
-		local node_pos = moveresult.collisions[1].node_pos
+	if move_result.collisions[1].type == "node" then
+		local node_pos = move_result.collisions[1].node_pos
 		local arrow_pos = entity.object:get_pos()
 
 		local dist = sqr( (node_pos.x - arrow_pos.x)^2 +
@@ -73,7 +73,7 @@ entity.object:set_velocity({x = vel.x/15, y = vel.y/15, z = vel.z/15})
 	entity.object:set_acceleration({x = 0, y = 0, z = 0})
 	entity.timer_is_start = true
 
-	local target = moveresult.collisions[1].object
+	local target = move_result.collisions[1].object
 
 	hit_handling(entity, target, name, def)
 end

--- a/mods/lord/_experimental/lord_bows/mechanics_throwing.lua
+++ b/mods/lord/_experimental/lord_bows/mechanics_throwing.lua
@@ -93,7 +93,7 @@ local function player_reset_slowdown(player)
 end
 
 -- Выстрел
-local function arrow_shot(player)
+local function arrow_shot(player, stack)
 	local inv        = player:get_inventory()
 	local look_dir   = player:get_look_dir()
 	local player_pos = player:get_pos()
@@ -108,6 +108,8 @@ local function arrow_shot(player)
 				z = look_dir.z * value[2] * charge,
 			})
 			arrow:set_acceleration({x = 0, y = GRAVITY * (-1), z = 0})
+			arrow:get_luaentity().shooter = player
+			stack:add_wear(5000)
 			inv:remove_item("main", key)
 			return
 		end
@@ -161,7 +163,7 @@ lord.register_on_release(function(player, control_name)
 		return
 	end
 
-	arrow_shot(player)
+	arrow_shot(player, stack)
 
 	throwing.charges[player:get_player_name()] = 0
 


### PR DESCRIPTION
**Описание PR:**
Добавил:
- Лук изнашивается при выстреле
- При попадании по мобу, моб агрится на игрока
- Исправления рикошета. Пояснение: из-за несовершенности физического движка МТ, стрела на высокой скорости может отрикошетить от блока и зависнусть в воздухе, посчитав, что она в этот самый блок "попала". Исправление заключается в том, что если стрела на момент рассчета оказалась слишком далеко от блока, с которым столкнулась, она теряет свою скорость в 15 раз, а не просто зависает в воздухе.
- Стрелы теперь удаляются, даже если были выгружены и загружены обратно (как сущность). Примечание: те стрелы, что висят на полигоне НЕ ИСЧЕЗНУТ.

Все еще нету:
- Крафта стрел и луков
- Переводов
- Док-блоков........

**Рекомендации к тесту**
- Проверить все, что было заявлено в "добавил"
- Оценить скорость стрелы и замедление игрока с точки зрения баланса

**Дополнительная информация:**

#966 