### PR TITLE
Set use_texture_alpha = false for mobs

### DIFF
--- a/mods/_various/mobs/api.lua
+++ b/mods/_various/mobs/api.lua
@@ -2445,7 +2445,7 @@ minetest.register_entity(name, {
 	id = 0,
 	game_name = "mob",
 	texture_list = def.textures,
-	use_texture_alpha = def.use_texture_alpha or true,
+	use_texture_alpha = def.use_texture_alpha or false,
 	child_texture = def.child_texture,
 	docile_by_day = def.docile_by_day or false,
 	time_of_day = 0.5,


### PR DESCRIPTION
**Описание PR:**

fix: #1366 

**Рекомендации к тесту:**

1. проверить что все мобы видны в любых комбинациях положения игрока, моба, полупрозрачного объекта
2. проверить что ничего не поломано в других местах (может быть в use_texture_alpha = true был смысл)
