### PR TITLE
Added default values for lord_ground.mordor_to/from settings

### DIFF
--- a/mods/lord/Blocks/lord_ground/src/ground/config.lua
+++ b/mods/lord/Blocks/lord_ground/src/ground/config.lua
@@ -1,12 +1,3 @@
-local mordor_from = { 4500, -15000, }
-local mordor_from_setting = minetest.settings:get("lord_ground.mordor_lands.from")
-if mordor_from_setting ~= nil then mordor_from = string.split(mordor_from_setting, ",") end
-
-local mordor_to = { 20000,  -8000, }
-local mordor_to_setting = minetest.settings:get("lord_ground.mordor_lands.to")
-if mordor_to_setting ~= nil then mordor_to = string.split(mordor_to_setting, ",") end
-
-
 --- @class ground.Config
 local config = {
 	dirts = {
@@ -37,13 +28,23 @@ local config = {
 	--sand = {
 		-- mordor
 	--},
-	mordor_lands = {
-		from          = { x = tonumber(mordor_from[1]), z = tonumber(mordor_from[2]) },
-		to            = { x = tonumber(mordor_to[1]), z = tonumber(mordor_to[2]) },
+}
+
+local mordor_from_setting = minetest.settings:get("lord_ground.mordor_lands.from")
+local mordor_to_setting = minetest.settings:get("lord_ground.mordor_lands.to")
+
+if mordor_from_setting and mordor_to_setting then
+	local mordor_from = string.split(mordor_from_setting)
+	local mordor_to = string.split(mordor_to_setting)
+	config.mordor_lands = {
+		from = { x = tonumber(mordor_from[1]), z = tonumber(mordor_from[2]) },
+		to   = { x = tonumber(mordor_to[1]), z = tonumber(mordor_to[2]) },
 		exclude_dirts = { "lord_ground:dirt_dunland", "lord_ground:dirt_mirkwood" },
 		covers_with   = { "lord_rocks:mordor_stone", "lord_ground:coarse_dirt", "lord_ground:stony_dirt" },
-	},
-}
+	}
+else
+	minetest.log("warning", "lord_ground.mordor_lands.from/to aren't set, disabling the functionality...")
+end
 
 
 return config

--- a/mods/lord/Blocks/lord_ground/src/ground/spreading.lua
+++ b/mods/lord/Blocks/lord_ground/src/ground/spreading.lua
@@ -9,6 +9,7 @@ local RACE_ORC = "orc"
 --- @param api    ground.API
 --- @param config ground.Config
 local function deferred_register_mordor_lands_spreading_abm(api, config)
+	if config.mordor_lands == nil then return end
 	minetest.register_on_mods_loaded(function()
 		local exclude_dirts    = config.mordor_lands.exclude_dirts
 		local covers_with      = config.mordor_lands.covers_with


### PR DESCRIPTION
**Описание PR:**

Добавлены значения по умолчанию для настроек `lord_ground.mordor_lands.from` и `lord_ground.mordor_lands.to`, если таковые не найдены в `minetest.conf`.

**Рекомендации к тесту:**

Добавлять и убирать оные в `minetest.conf`.

**Дополнительная информация:**

Fixes #1360.
