### PR TITLE
feature: max players in clan (fixes #1346)

### DIFF
--- a/mods/lord/Player/clans/init.lua
+++ b/mods/lord/Player/clans/init.lua
@@ -41,7 +41,11 @@ clans.err = {
 	[2] = "given player(s) is(are) already assigned to some other clan",
 	[3] = "there is no clan with given name",
 	[4] = "there is no such player in this clan",
+	[5] = "max players reached!",
 }
+
+---@type integer readonly
+clans.max_players_in_clan = tonumber(minetest.settings:get("clans.max_players_in_clan")) or 10
 
 --- @param name string
 --- @param title string
@@ -49,6 +53,7 @@ clans.err = {
 --- @return boolean,string|nil
 function clans.create_clan(name, title, members)
 	if clans.get_by_name(name) ~= nil then return false, clans.err[1] end
+	if #members > clans.max_players_in_clan then return false, clans.err[5] end
 	for _, m in ipairs(members) do
 		if clans.get_by_player_name(m) ~= nil then return false, clans.err[2] end
 	end
@@ -73,6 +78,7 @@ function clans.add_player_to_clan(clan_name, player_name)
 	if clans.get_by_player_name(player_name) ~= nil then return false, clans.err[2] end
 	local clan = clans.get_by_name(clan_name)
 	if clan == nil then return false, clans.err[3] end
+	if #clan.players+1 > clans.max_players_in_clan then return false, clans.err[5] end
 
 	table.insert(clan.players, player_name)
 	clan_storage.set(clan)

--- a/mods/lord/Player/clans/locale/clans.en.tr
+++ b/mods/lord/Player/clans/locale/clans.en.tr
@@ -20,3 +20,5 @@ Given player(s) is(are) added to clan @1.=Given player(s) is(are) added to clan 
 Removes given player from given clan.=Removes given player from given clan.
 Player @1 was removed from clan @2.=Player @1 was removed from clan @2.
 Player @1 does not member of the @2 clan.=Player @1 does not member of the @2 clan.
+Too much players in clan (max is @1). Can't create clan @2.=Too much players in clan (max is @1). Can't create clan @2.
+Too much players in clan (max is @1). Can't add player(s).=Too much players in clan (max is @1). Can't add player(s).

--- a/mods/lord/Player/clans/locale/clans.en.tr
+++ b/mods/lord/Player/clans/locale/clans.en.tr
@@ -20,5 +20,5 @@ Given player(s) is(are) added to clan @1.=Given player(s) is(are) added to clan 
 Removes given player from given clan.=Removes given player from given clan.
 Player @1 was removed from clan @2.=Player @1 was removed from clan @2.
 Player @1 does not member of the @2 clan.=Player @1 does not member of the @2 clan.
-Too much players in clan (max is @1). Can't create clan @2.=Too much players in clan (max is @1). Can't create clan @2.
-Too much players in clan (max is @1). Can't add player(s).=Too much players in clan (max is @1). Can't add player(s).
+Too many players in clan (max is @1). Can't create clan @2.=Too many players in clan (max is @1). Can't create clan @2.
+Too many players in clan (max is @1). Can't add player(s).=Too many players in clan (max is @1). Can't add player(s).

--- a/mods/lord/Player/clans/locale/clans.ru.tr
+++ b/mods/lord/Player/clans/locale/clans.ru.tr
@@ -20,5 +20,5 @@ Given player(s) is(are) added to clan @1.=Данные игроки добавл
 Removes given player from given clan.=Удаляет данного игрока из данного клана.
 Player @1 was removed from clan @2.=Игрок @1 был удалён из клана @2.
 Player @1 does not member of the @2 clan.=Игрок @1 не состоит в клане @2.
-Too much players in clan (max is @1). Can't create clan @2.=Слишком много игроков в клане (максимум - @1). Создать клан @2 невозможно.
-Too much players in clan (max is @1). Can't add player(s).=Слишком много игроков в калне (максимум - @1). Невозможно добавить игроков.
+Too many players in clan (max is @1). Can't create clan @2.=Слишком много игроков в клане (максимум - @1). Создать клан @2 невозможно.
+Too many players in clan (max is @1). Can't add player(s).=Слишком много игроков в калне (максимум - @1). Невозможно добавить игроков.

--- a/mods/lord/Player/clans/locale/clans.ru.tr
+++ b/mods/lord/Player/clans/locale/clans.ru.tr
@@ -20,3 +20,5 @@ Given player(s) is(are) added to clan @1.=Данные игроки добавл
 Removes given player from given clan.=Удаляет данного игрока из данного клана.
 Player @1 was removed from clan @2.=Игрок @1 был удалён из клана @2.
 Player @1 does not member of the @2 clan.=Игрок @1 не состоит в клане @2.
+Too much players in clan (max is @1). Can't create clan @2.=Слишком много игроков в клане (максимум - @1). Создать клан @2 невозможно.
+Too much players in clan (max is @1). Can't add player(s).=Слишком много игроков в калне (максимум - @1). Невозможно добавить игроков.

--- a/mods/lord/Player/clans/locale/template.txt
+++ b/mods/lord/Player/clans/locale/template.txt
@@ -20,3 +20,5 @@ Given player(s) is(are) added to clan @1.=
 Removes given player from given clan.=
 Player @1 was removed from clan @2.=
 Player @1 does not member of the @2 clan.=
+Too much players in clan (max is @1). Can't create clan @2.=
+Too much players in clan (max is @1). Can't add player(s).=

--- a/mods/lord/Player/clans/locale/template.txt
+++ b/mods/lord/Player/clans/locale/template.txt
@@ -20,5 +20,5 @@ Given player(s) is(are) added to clan @1.=
 Removes given player from given clan.=
 Player @1 was removed from clan @2.=
 Player @1 does not member of the @2 clan.=
-Too much players in clan (max is @1). Can't create clan @2.=
-Too much players in clan (max is @1). Can't add player(s).=
+Too many players in clan (max is @1). Can't create clan @2.=
+Too many players in clan (max is @1). Can't add player(s).=

--- a/mods/lord/Player/clans/src/commands.lua
+++ b/mods/lord/Player/clans/src/commands.lua
@@ -49,6 +49,12 @@ minetest.register_chatcommand("clans.register", {
 			return false, S("Clan @1 already exists.", clan_name)
 		elseif err == clans.err[2] then
 			return false, S("A player from given is already assigned to a clan. Can't create clan @1.", clan_name)
+		elseif err == clans.err[5] then
+			return false, S(
+				"Too much players in clan (max is @1). Can't create clan @2.",
+				clans.max_players_in_clan,
+				clan_name
+			)
 		end
 	end
 })
@@ -92,6 +98,11 @@ minetest.register_chatcommand("clans.add_player", {
 						return false, S("Clan @1 does not exist.", clan_name)
 					elseif err == clans.err[2] then
 						return false, S("A player from given is already assigned to a clan.")
+					elseif err == clans.err[5] then
+						return false, S(
+							"Too much players in clan (max is @1). Can't add player(s).",
+							clans.max_players_in_clan
+						)
 					end
 				end
 			end

--- a/mods/lord/Player/clans/src/commands.lua
+++ b/mods/lord/Player/clans/src/commands.lua
@@ -51,7 +51,7 @@ minetest.register_chatcommand("clans.register", {
 			return false, S("A player from given is already assigned to a clan. Can't create clan @1.", clan_name)
 		elseif err == clans.err[5] then
 			return false, S(
-				"Too much players in clan (max is @1). Can't create clan @2.",
+				"Too many players in clan (max is @1). Can't create clan @2.",
 				clans.max_players_in_clan,
 				clan_name
 			)
@@ -100,7 +100,7 @@ minetest.register_chatcommand("clans.add_player", {
 						return false, S("A player from given is already assigned to a clan.")
 					elseif err == clans.err[5] then
 						return false, S(
-							"Too much players in clan (max is @1). Can't add player(s).",
+							"Too many players in clan (max is @1). Can't add player(s).",
 							clans.max_players_in_clan
 						)
 					end


### PR DESCRIPTION
**Описание PR:**

Добавлена настройка на максимальное количество игроков в клане. По умолчанию - 10.

**Рекомендации к тесту:**

Чат-команды на добавление игрока в клан `clans.add_player` и сама регистрация клана `clans.register`.

**Дополнительная информация:**

Fixes #1346.
