### PR TITLE
Feature: raid notification cooldown. Closes #1325

### DIFF
--- a/mods/lord/Blocks/clan_node/src/chest/node.lua
+++ b/mods/lord/Blocks/clan_node/src/chest/node.lua
@@ -17,13 +17,13 @@ local raid_notification_is_blocked = {
 ---@param clan_name string
 ---@param clan_title string
 local function send_raid_notification(clan_name, clan_title)
+	minetest.chat_send_all(minetest.colorize("red", S("Clan @1 is under the raid", clan_title)))
 	if raid_notification_is_blocked[clan_name] then return end
 	raid_notification_is_blocked[clan_name] = true
 	minetest.after(raid_notification_cooldown, function()
 		raid_notification_is_blocked[clan_name] = nil
 	end)
 
-	minetest.chat_send_all(minetest.colorize("red", S("Clan @1 is under the raid", clan_title)))
 	local sound = minetest.sound_play("clan_node_alert_bell", { gain = 0.5 })
 	minetest.after(15, function()
 		minetest.sound_fade(sound, 0.05, 0)

--- a/mods/lord/Blocks/clan_node/src/chest/node.lua
+++ b/mods/lord/Blocks/clan_node/src/chest/node.lua
@@ -4,6 +4,32 @@ local Form = require("chest.node.Form")
 
 local S = minetest.get_translator('clan_node')
 
+
+---@type number @seconds
+local raid_notification_cooldown = 50
+
+---@type table<string,boolean>
+local raid_notification_block = {
+	-- clan_name = true, -- raid notification was sent to clan recently
+	-- clan_name = nil,  --                 ...                long ago
+}
+
+---@param clan_name string
+---@param clan_title string
+local function send_raid_notification(clan_name, clan_title)
+	if raid_notification_block[clan_name] then return end
+	raid_notification_block[clan_name] = true
+	minetest.after(raid_notification_cooldown, function()
+		raid_notification_block[clan_name] = nil
+	end)
+
+	minetest.chat_send_all(minetest.colorize("red", S("Clan @1 is under the raid", clan_title)))
+	local sound = minetest.sound_play("clan_node_alert_bell", { gain = 0.5 })
+	minetest.after(15, function()
+		minetest.sound_fade(sound, 0.05, 0)
+	end)
+end
+
 local definition = {
 	description       = S("Clan Chest"),
 	tiles             = {
@@ -76,16 +102,26 @@ local definition = {
 		if (not chest_clan_name or not clans.clan_is_online(chest_clan_name)) and not is_admin then
 			return
 		end
+
+		-- check if clan exists
+		local chest_clan = clans.get_by_name(chest_clan_name)
+		if not chest_clan then
+			minetest.log(
+				"error",
+				string.format(
+					"Clan chest at {%s} doesn't have an existing owned clan - \"%s\"!",
+					table.concat({pos.x, pos.y, pos.z}, ", "),
+					chest_clan_name
+				)
+			)
+			return
+		end
+
 		local player_clan = clans.get_by_player(clicker)
 		local player_clan_name = player_clan and player_clan.name or nil
 		if not player_clan then	return end  -- open clan chest only for players from any clans, not for regular players
 		if player_clan_name ~= chest_clan_name and not is_admin then
-			local chest_clan = clans.get_by_name(chest_clan_name)
-			minetest.chat_send_all(minetest.colorize("red", S("Clan @1 is under the raid", chest_clan.title)))
-			local sound = minetest.sound_play("clan_node_alert_bell", { gain = 0.5 })
-			minetest.after(15, function()
-				minetest.sound_fade(sound, 0.05, 0)
-			end)
+			send_raid_notification(chest_clan_name, chest_clan.title)
 		end
 		Form:new(pos, clicker):open()
 	end,

--- a/mods/lord/Blocks/clan_node/src/chest/node.lua
+++ b/mods/lord/Blocks/clan_node/src/chest/node.lua
@@ -9,7 +9,7 @@ local S = minetest.get_translator('clan_node')
 local raid_notification_cooldown = 50
 
 ---@type table<string,boolean>
-local raid_notification_block = {
+local raid_notification_is_blocked = {
 	-- clan_name = true, -- raid notification was sent to clan recently
 	-- clan_name = nil,  --                 ...                long ago
 }
@@ -17,10 +17,10 @@ local raid_notification_block = {
 ---@param clan_name string
 ---@param clan_title string
 local function send_raid_notification(clan_name, clan_title)
-	if raid_notification_block[clan_name] then return end
-	raid_notification_block[clan_name] = true
+	if raid_notification_is_blocked[clan_name] then return end
+	raid_notification_is_blocked[clan_name] = true
 	minetest.after(raid_notification_cooldown, function()
-		raid_notification_block[clan_name] = nil
+		raid_notification_is_blocked[clan_name] = nil
 	end)
 
 	minetest.chat_send_all(minetest.colorize("red", S("Clan @1 is under the raid", clan_title)))


### PR DESCRIPTION
**Описание PR:**

Добавлен задержка на 50 секунд на оповещение о рейде клана во избежании спама им.

**Рекомендации к тесту:**

Тестировать рейды на клановские сундуки, кулдаун для каждого клана считается отдельно.

**Дополнительная информация:**

Closes #1325.
