### PR TITLE
Kick inactive players from clans

### DIFF
--- a/mods/lord/Player/clans/init.lua
+++ b/mods/lord/Player/clans/init.lua
@@ -106,7 +106,7 @@ function clans.remove_player_from_clan(clan_name, player_name)
 	return true, nil
 end
 
---- @return table
+--- @return table<string,clans.Clan>
 function clans.list()
 	return clan_storage.list()
 end
@@ -166,5 +166,6 @@ end)
 
 
 require("commands")
+require("last_login_kick")
 
 require = old_require

--- a/mods/lord/Player/clans/src/last_login_kick.lua
+++ b/mods/lord/Player/clans/src/last_login_kick.lua
@@ -1,0 +1,33 @@
+
+local min = 60
+local hour = min * 60
+local day = hour * 24
+local month = day * 30
+---@type number @in seconds
+local MAX_INACTIVE_PERIOD = month * 3
+
+local function kick_inactive_players_from_clan()
+	local auth_handler = minetest.get_auth_handler()
+	local time_now = os.time()
+	for clan_name, clan in pairs(clans.list()) do
+		for _, player in ipairs(clan.players) do
+			local last_login = auth_handler.get_auth(player).last_login
+			if last_login ~= nil and time_now - last_login > MAX_INACTIVE_PERIOD then
+				clans.remove_player_from_clan(clan_name, player)
+				minetest.log(
+					"info",
+					string.format(
+						"[clans] removed %s player from %s clan for being offline since %d",
+						player,
+						clan_name,
+						last_login
+					)
+				)
+			end
+		end
+	end
+end
+
+minetest.register_on_mods_loaded(
+	function() minetest.after(30, kick_inactive_players_from_clan) end -- HACK: waiting for auth system loading
+)

--- a/mods/lord/Player/clans/src/last_login_kick.lua
+++ b/mods/lord/Player/clans/src/last_login_kick.lua
@@ -28,6 +28,14 @@ local function kick_inactive_players_from_clan()
 	end
 end
 
-minetest.register_on_mods_loaded(
-	function() minetest.after(30, kick_inactive_players_from_clan) end -- HACK: waiting for auth system loading
-)
+--- Calls given function every day since server start with minetest.after
+---@param func fun()
+local function call_every_day(func)
+	func()
+	minetest.after(day, call_every_day, func)
+end
+
+minetest.register_on_mods_loaded(function()
+	-- HACK: waiting for auth system loading:
+	minetest.after(30, call_every_day, kick_inactive_players_from_clan)
+end)

--- a/util/mt-ide-helper/definitions/AuthenticationHandlerDefinition.lua
+++ b/util/mt-ide-helper/definitions/AuthenticationHandlerDefinition.lua
@@ -1,0 +1,51 @@
+---@class AuthenticationHandlerGetAuth
+---@field password string
+---@field priveleges table<string,number>
+---@field last_login number|nil
+
+-- Used by `minetest.register_authentication_handler`.
+---@class AuthenticationHandlerDefinition
+local AuthenticationHandlerDefinition = {
+	--- Get authentication data for existing player `name` (`nil` if player
+    --- doesn't exist).
+    --- Returns following structure:
+    --- `{password=<string>, privileges=<table>, last_login=<number or nil>}`
+	---@type fun(name:string):AuthenticationHandlerGetAuth
+    get_auth = function(name) end,
+
+	--- Create new auth data for player `name`.
+    --- Note that `password` is not plain-text but an arbitrary
+    --- representation decided by the engine.
+	---@type fun(name:string, password:string)
+    create_auth = function(name, password) end,
+
+	--- Delete auth data of player `name`.
+    --- Returns boolean indicating success (false if player is nonexistent).
+	---@type fun(name:string)
+    delete_auth = function(name) end,
+
+	--- Set password of player `name` to `password`.
+    --- Auth data should be created if not present.
+	---@type fun(name:string, password:string)
+    set_password = function(name, password) end,
+
+    --- Set privileges of player `name`.
+    --- `privileges` is in table form, auth data should be created if not
+    --- present.
+	---@type fun(name:string, priveleges:table<string,number>)
+    set_privileges = function(name, privileges) end,
+
+    --- Reload authentication data from the storage location.
+    --- Returns boolean indicating success.
+	---@type fun():boolean
+    reload = function() end,
+
+    --- Called when player joins, used for keeping track of last_login
+	---@type fun(name:string)
+    record_login = function(name) end,
+
+    --- Returns an iterator (use with `for` loops) for all player names
+    --- currently in the auth database
+	---@type fun():fun()
+    iterate = function() end,
+}

--- a/util/mt-ide-helper/minetest_types.lua
+++ b/util/mt-ide-helper/minetest_types.lua
@@ -150,6 +150,7 @@ function minetest.is_nan(arg) end
 --- * This value might overflow on certain 32-bit systems!
 ---
 --- [View in lua_api.txt](https://github.com/minetest/minetest/blob/5.4.1/doc/lua_api.txt#L3269-L3271)
+---@return number
 function minetest.get_us_time() end
 --- returns a position.
 --- * returns the exact position on the surface of a pointed node
@@ -839,6 +840,7 @@ function minetest.get_player_ip(name) end
 ---   `local auth_data = minetest.get_auth_handler().get_auth(playername)`
 ---
 --- [View in lua_api.txt](https://github.com/minetest/minetest/blob/5.4.1/doc/lua_api.txt#L4807-L4810)
+---@return AuthenticationHandlerDefinition
 function minetest.get_auth_handler() end
 --- * Must be called by the authentication handler for privilege changes.
 --- * `name`: string; if omitted, all auth data should be considered modified
@@ -1703,6 +1705,9 @@ function minetest.sound_fade(handle, step, gain) end
 --- * Optional: Variable number of arguments that are passed to `func`
 ---
 --- [View in lua_api.txt](https://github.com/minetest/minetest/blob/5.4.1/doc/lua_api.txt#L5420-L5422)
+---@param time number @in seconds
+---@param func fun()
+---@return table @job (job:cancel() to stop)
 function minetest.after(time, func, ...) end
 --- * Cancels the job function from being called
 function job:cancel() end


### PR DESCRIPTION
**Описание PR:**

Автоматическое исключение неактивных игроков (>90 дней) из кланов. Срабатывает на каждом запуске сервера и потом каждые сутки после оного.

**Рекомендации к тесту:**

Тестировать немного затруднительно...

**Дополнительная информация:**

Fixes #1324.
