### PR TITLE
Clan prefix removing/adding instantly

### DIFF
--- a/mods/lord/Player/clans/init.lua
+++ b/mods/lord/Player/clans/init.lua
@@ -42,44 +42,33 @@ clans.err = {
 ---@type integer readonly
 clans.max_players_in_clan = tonumber(minetest.settings:get("clans.max_players_in_clan")) or 10
 
----@param nick string
----@return Player|nil @nil if player is offline
-local function nick2player(nick)
-	local player = minetest.get_player_by_name(nick)
-	local players = minetest.get_connected_players()
-	if not table.contains(players, player) then
-		return nil
-	end
-	return player
-end
---- Note: if function receives PlayerObj it doesn't check is player online.
----@param player Player|string @Player or player name
+---@param player Player|string|nil @Player or player name
 ---@param clan_title string
 ---@return boolean @completed or not
 local function add_clan_prefix_to_player_name(player, clan_title)
 	if type(player) == "string" then
-		local player_or_nil = nick2player(player)
-		if not player_or_nil then return false end -- player is offline
-		---@type Player
-		player = player_or_nil -- HACK: type hints perversion
+		player = minetest.get_player_by_name(player)
 	end
-	player:set_nametag_attributes({
-		text = player:get_player_name() .. " " .. minetest.colorize("lime", "["..clan_title.."]"),
-	})
-	return true
+	if player then
+		player:set_nametag_attributes({
+			text = player:get_player_name() .. " " .. minetest.colorize("lime", "["..clan_title.."]"),
+		})
+		return true
+	end
+	return false
 end
---- Note: if function receives PlayerObj it doesn't check is player online.
----@param player Player|string @Player or player name
+
+---@param player Player|string|nil @Player or player name
 ---@return boolean @completed or not
 local function reset_player_name(player)
 	if type(player) == "string" then
-		local player_or_nil = nick2player(player)
-		if not player_or_nil then return false end -- player is offline
-		---@type Player
-		player = player_or_nil -- HACK: type hints perversion
+		player = minetest.get_player_by_name(player)
 	end
-	player:set_nametag_attributes({	text = player:get_player_name(), })
-	return true
+	if player then
+		player:set_nametag_attributes({	text = player:get_player_name(), })
+		return true
+	end
+	return false
 end
 
 --- @param name string

--- a/mods/lord/Player/clans/src/storage.lua
+++ b/mods/lord/Player/clans/src/storage.lua
@@ -42,6 +42,7 @@ local cache = storage2cache()
 --- @param name string
 --- @return clans.Clan|nil
 function clan_storage.get(name)
+	if cache[name] == nil then return nil end
 	return table.copy(cache[name])
 end
 

--- a/util/mt-ide-helper/minetest_types.lua
+++ b/util/mt-ide-helper/minetest_types.lua
@@ -1007,7 +1007,7 @@ function minetest.add_item(pos, item) end
 ---
 --- [View in lua_api.txt](https://github.com/minetest/minetest/blob/5.4.1/doc/lua_api.txt#L4913-L4913)
 --- @param name string
---- @return Player
+--- @return Player|nil
 function minetest.get_player_by_name(name) end
 --- Returns a list of
 ---   ObjectRefs.


### PR DESCRIPTION
**Описание PR:**

Убирает или добавляет префикс клана в ник игрока "в прямом эфире". Немного изменён цвет префикса, теперь он `lime` (см. [named colors](https://www.w3.org/TR/css-color-4/#named-color)).

Также исправлен баг с падением из-за функции `clan_storage.get`.

**Рекомендации к тесту:**

Тест всего и вся нужен будет к релизу.

**Дополнительная информация:**

Fixes #1397. Небольшая путаница с коммитами из-за того, что сделал слияние с веткой из предыдущего PR (#1396), чтобы забрать один неслитый коммит (e2cc63a8cd7417c6abafc4051eec45ca80eca0bb).
