### PR TITLE
Removed unnecessary clear craft statements

### DIFF
--- a/mods/lord/_overwrites/MTG/farming/init.lua
+++ b/mods/lord/_overwrites/MTG/farming/init.lua
@@ -93,7 +93,5 @@ minetest.override_item("farming:cotton_wild", {drop = {
 
 
 -- Clear hoes tools and craft registration
-minetest.clear_craft({output = "farming:hoe_mese"})
 minetest.unregister_item("farming:hoe_mese")
-minetest.clear_craft({output = "farming:hoe_diamond"})
 minetest.unregister_item("farming:hoe_diamond")


### PR DESCRIPTION
**Описание PR:**

Удалены ненужные вызовы функции удаления крафтов у алмазной и мезе- мотыг, так как в MTG они уже удалены ввиду того, что их [тоже хотят удалить в следующем релизе](https://github.com/minetest/minetest_game/blob/511619253facd524df75ae44537d7b2c4e30a8db/mods/farming/hoes.lua#L30).

**Рекомендации к тесту:**

Увидеть, что в журнале нет больше ошибок с грифом "WARNING".

**Дополнительная информация:**

Fixes #710.
