### PR TITLE
Improved /lists debug tool

### DIFF
--- a/mods/lord/Game/debugtools/lists.lua
+++ b/mods/lord/Game/debugtools/lists.lua
@@ -6,35 +6,33 @@ minetest.register_privilege("lists", {
 	description = "Возможность выводить списки зарегестрированных блоков, инструментов и предметов в файлы",
 })
 
+--- Writes given definition table (minetest.registered_nodes/tools/craftitems) to given text file.
+---@param filepath string
+---@param defs NodeDefinition[]|table<string,table>
+local function def2file(filepath, defs)
+	local output = io.open(filepath, "w")
+	if not output then error("[debugtools] can't open file: "..filepath) end
+	local list = {}
+	for name, def in pairs(defs) do
+		if name == "air" then name = ":air" end
+		if name == "ignore" then name = ":ignore" end
+		local desc = minetest.get_translated_string("ru", def.description)
+		local escaped_desc = string.gsub(desc, "\n", " ")
+		table.insert(list, string.format("%s\t%s", name, escaped_desc))
+	end
+	output:write(table.concat(list, "\n"))
+	io.close(output)
+end
+
 minetest.register_chatcommand("lists", {
 	description =
 		"Вывести списки зарегестрированных блоков, инструментов и предметов в файлы nodes.list, tools.list, items.list",
 	privs = {lists = true},
 	func = function(name)
-		local List = ""
-		local output = io.open(nodes_file, "w")
-		for n, d in pairs(minetest.registered_nodes) do
-			if n == "air" then n = ":air" end
-			if n == "ignore" then n = ":ignore" end
-			List = List..n..":"..string.gsub(d.description, "\n", " ").."\n"
-		end
-		output:write(List)
-		io.close(output)
-
-		List = ""
-		output = io.open(tools_file, "w")
-		for n, d in pairs(minetest.registered_tools) do
-			List = List..n..":"..string.gsub(d.description, "\n", " ").."\n"
-		end
-		output:write(List)
-		io.close(output)
-
-		List = ""
-		output = io.open(items_file, "w")
-		for n, d in pairs(minetest.registered_craftitems) do
-			List = List..n..":"..string.gsub(d.description, "\n", " ").."\n"
-		end
-		output:write(List)
-		io.close(output)
+		local c = os.clock()
+		def2file(nodes_file, minetest.registered_nodes)
+		def2file(tools_file, minetest.registered_tools)
+		def2file(items_file, minetest.registered_craftitems)
+		return true, string.format("Успешно записано! Выполнение команды заняло: %f сек.", os.clock() - c)
 	end
 })


### PR DESCRIPTION
**Описание PR:**

Улучшено поведение команды `/lists`. Теперь описание переводится перед записью в файл (`minetest.get_translated_string`).

**Рекомендации к тесту:**

Работоспособность команды.

**Дополнительная информация:**

Небольшая проблема с тем, что пишется лишний раз время исполнения команды.
