### PR TITLE
Beautifying clans chat commands

### DIFF
--- a/mods/lord/Player/clans/locale/clans.en.tr
+++ b/mods/lord/Player/clans/locale/clans.en.tr
@@ -1,6 +1,6 @@
 # textdomain: clans
 Lists all existing clans. Blocked clans are marked with gray color.=Lists all existing clans. Blocked clans are marked with gray color.
-List of clans:@n@1=List of clans:@n@1
+List of clans in format '<clan title> (<clan name>) — <status>':=List of clans in format '<clan title> (<clan name>) — <status>':
 Shows given clan information.=Shows given clan information.
 Clan @1 does not exist.=Clan @1 does not exist.
 <clan name> <clan title> [list of players separated by space]=<clan name> <clan title> [list of players separated by space]
@@ -29,3 +29,4 @@ Clan @1 is blocked!=Clan @1 is blocked!
 Toggles clan block.=Toggles clan block.
 Clan @1 unblocked succesfully.=Clan @1 unblocked succesfully.
 Clan @1 blocked succesfully.=Clan @1 blocked succesfully.
+Clan=Clan

--- a/mods/lord/Player/clans/locale/clans.ru.tr
+++ b/mods/lord/Player/clans/locale/clans.ru.tr
@@ -1,6 +1,6 @@
 # textdomain: clans
 Lists all existing clans. Blocked clans are marked with gray color.=Показывает список существующих кланов. Серым цветом помечены заблокированные кланы.
-List of clans:@n@1=Список кланов:@n@1
+List of clans in format '<clan title> (<clan name>) — <status>':=Список кланов виде '<название клана> (<id клана>) — <статус>':
 Shows given clan information.=Показывает информацию о данном клане.
 Clan @1 does not exist.=Клана @1 не существует.
 <clan name> <clan title> [list of players separated by space]=<ID клана> <тайтл клана> [список игроков через пробел]
@@ -29,3 +29,4 @@ Clan @1 is blocked!=Клан @1 заблокирован!
 Toggles clan block.=Переключает блокировку клана.
 Clan @1 unblocked succesfully.=Клан @1 успешно разблокирован.
 Clan @1 blocked succesfully.=Клан @1 успешно заблокирован.
+Clan=Клан

--- a/mods/lord/Player/clans/locale/template.txt
+++ b/mods/lord/Player/clans/locale/template.txt
@@ -1,6 +1,6 @@
 # textdomain: clans
 Lists all existing clans. Blocked clans are marked with gray color.=
-List of clans:@n@1=
+List of clans in format '<clan title> (<clan name>) — <status>':=
 Shows given clan information.=
 Clan @1 does not exist.=
 <clan name> <clan title> [list of players separated by space]=
@@ -29,3 +29,4 @@ Clan @1 is blocked!=
 Toggles clan block.=
 Clan @1 unblocked succesfully.=
 Clan @1 blocked succesfully.=
+Clan=

--- a/mods/lord/Player/clans/src/clans/commands.lua
+++ b/mods/lord/Player/clans/src/clans/commands.lua
@@ -7,14 +7,19 @@ minetest.register_chatcommand("clans.list", {
 	func = function(_, _)
 		local clans_str = ""
 		for _, clan in pairs(clans.list()) do
-			local clan1_str = string.format("%s \"%s\"", colorize("gray", clan.name), colorize(clans.COLOR, clan.title))
-			if clan.is_blocked then
-				clan1_str = clan1_str.." "..S("[Blocked]")
-				clan1_str = colorize("silver", clan1_str)
+			local id_str = clan.name
+			local title_str = minetest.colorize(clans.COLOR, clan.title)
+			local status_str = minetest.colorize("green", "online")
+			if not clans.clan_is_online(clan.name) then
+				status_str = "offline"
+				if clan.is_blocked then
+					status_str = "blocked"
+				end
+				status_str = minetest.colorize("red", status_str)
 			end
-			clans_str = clans_str .. "\n" .. clan1_str
+			clans_str = clans_str .. id_str.."\t"..title_str.."\t"..status_str.."\n"
 		end
-		return true, "\n" .. S("List of clans:@n@1", clans_str) .. "\n\n"
+		return true, "\n" .. S("List of clans:@n@1", clans_str) .. "\n"
 	end
 })
 


### PR DESCRIPTION
**Описание PR:**

Делает красивым и няшным выхлоп команд `/clans.list` и `/clans.show`! Ня :3

**Рекомендации к тесту:**

Запуск команд `/clans.list` и `clans.show` с различными кланами и условиями онлайна этих кланов и его игроков.

**Дополнительная информация:**

Closes #1433. Closes #1434.

*P.S. В будущем цвета нужно будет унифицировать в каком-нибудь моде `lord_colors`, где будут хранится константы по цветам типа `lord_colors.commands.ok` как успешное выполнение команды или `lord_colors.online` для подсвечивания чего-либо как онлайн. Но это так - мечты идеалиста.*