### PR TITLE
Fixed removing nodes with paintings

### DIFF
--- a/mods/_various/painting/init.lua
+++ b/mods/_various/painting/init.lua
@@ -302,6 +302,11 @@ minetest.register_craftitem("painting:paintedcanvas", {
 			return
 		end
 
+		local possibly_replaced_node = minetest.get_node(pos).name
+		if possibly_replaced_node ~= "air" then
+			return
+		end
+
 		local under = pointed_thing.under
 
 		local wm = minetest.dir_to_wallmounted(vector.subtract(under, pos))

--- a/util/mt-ide-helper/minetest_types.lua
+++ b/util/mt-ide-helper/minetest_types.lua
@@ -923,6 +923,8 @@ function minetest.remove_node(pos) end
 ---   returns `{name="ignore", param1=0, param2=0}` for unloaded areas.
 ---
 --- [View in lua_api.txt](https://github.com/minetest/minetest/blob/5.4.1/doc/lua_api.txt#L4860-L4863)
+---@param pos Position
+---@return Node
 function minetest.get_node(pos) end
 --- * Same as `get_node` but returns `nil` for unloaded areas.
 ---


### PR DESCRIPTION
**Описание PR:**

Закрывает давний баг. Потом закрою в оригинальном репозитории для обновления.

**Рекомендации к тесту:**

Протестировать удаление блоков картиной. Под водой картина ставится не должна - так задумано.

**Дополнительная информация:**

Fixes #319.
