### PR TITLE
Changing salt to salt_block as product of salt bucket

### DIFF
--- a/mods/lord/Tools/lord_bucket/init.lua
+++ b/mods/lord/Tools/lord_bucket/init.lua
@@ -49,7 +49,7 @@ minetest.mod(function(mod)
 	})
 
 	minetest.register_craft({
-		output       = "lottores:salt",
+		output       = "lottores:salt_block",
 		recipe       = { { "bucket:bucket_salt" } },
 		replacements = {
 			{ "bucket:bucket_salt", "bucket:bucket_empty" },


### PR DESCRIPTION
**Описание PR:**

Makes a salt bucket produce a salt block instead of a single salt. This solves half of the salt creation problem.

**Рекомендации к тесту:**

Still trying to figure out GIT, so take all this with a _grain of salt._

**Дополнительная информация:**

Related: #1792
