### PR TITLE
Solving white mushroom spore problem. Relates to #1799

### DIFF
--- a/mods/lord/Blocks/lottfarming/white.lua
+++ b/mods/lord/Blocks/lottfarming/white.lua
@@ -4,6 +4,11 @@ minetest.register_craftitem("lottfarming:white_mushroom_spore", {
 	description = S("White Mushroom Spores"),
 	inventory_image = "lottfarming_white_mushroom_spore.png",
 	on_place = function(itemstack, placer, pointed_thing)
+		local ptu = pointed_thing.under
+		local nu = minetest.get_node(ptu)
+		if minetest.registered_nodes[nu.name].on_rightclick then
+			return minetest.registered_nodes[nu.name].on_rightclick(ptu, nu, placer, itemstack)
+		end
 		return place_spore(itemstack, placer, pointed_thing, "lottfarming:white_mushroom_1", 9)
 	end,
 })


### PR DESCRIPTION
**Описание PR:**

An attempt to solve #1799, where specifically the `lottfarming:white_mushroom_spore` can't be placed onto `itemframes:frame` and `itemframes:protected_frame`.

**Рекомендации к тесту:**

Test, that `lottfarming:white_mushroom_spore` can be inserted into frames `itemframes:frame` and `itemframes:protected_frame`.

**Дополнительная информация:**

Closes #1799
