### PR TITLE
1792_water-bottle-to-salt. Closes #1792

### DIFF
--- a/mods/lord/Tools/lord_vessels/mod.conf
+++ b/mods/lord/Tools/lord_vessels/mod.conf
@@ -1,2 +1,2 @@
 name = lord_vessels
-depends = builtin, default, vessels
+depends = builtin, default, vessels, lottores

--- a/mods/lord/Tools/lord_vessels/src/bottles.lua
+++ b/mods/lord/Tools/lord_vessels/src/bottles.lua
@@ -33,3 +33,13 @@ minetest.register_node('lord_vessels:glass_bottle_water', {
 	groups          = { vessel = 1, dig_immediate = 3, attached_node = 1 },
 	sounds          = default.node_sound_glass_defaults(),
 })
+
+minetest.register_craft({
+	type = "cooking",
+	output = "lottores:salt 5",
+	recipe = "lord_vessels:glass_bottle_water",
+	cooktime = 7,
+	replacements = {
+		{ "lord_vessels:glass_bottle_water", "vessels:glass_bottle" },
+	},
+})


### PR DESCRIPTION
**Описание PR:**

Adds a cooking recipe which makes it possible to make `lottores:salt` from `lord_vessels:glass_bottle_water`.

**Рекомендации к тесту:**

Tested, although it gives back only a single `vessels:glass_bottle`, no matter how many `lord_vessels:glass_bottle_water` is put in the furnace stacked. I'm not sure if furnace can give back all the empty glass bottles - if it can, then this PR is not the proper solution.

**Дополнительная информация:**

Related: #1792