### PR TITLE
Fix #1938: Projectiles now always start a timer.

### DIFF
--- a/mods/lord/Core/projectiles/src/projectiles/entity.lua
+++ b/mods/lord/Core/projectiles/src/projectiles/entity.lua
@@ -232,7 +232,7 @@ local register_projectile_entity = function(name, entity_reg)
 		initial_properties = table.merge(initial_properties, entity_reg.initial_properties),
 		_life_timer         = entity_reg.life_timer or 90,
 		_shooter            = nil,
-		_timer_is_started   = false,
+		_timer_is_started   = entity_reg.timer_is_started or true,
 		_collision_count    = 0,
 		_sound_hit_node     = entity_reg.sound_hit_node,
 		_sound_hit_object   = entity_reg.sound_hit_object,
@@ -284,7 +284,7 @@ local register_projectile_entity = function(name, entity_reg)
 			end
 			local staticdata_table = minetest.deserialize(staticdata)
 
-			self._timer_is_started = staticdata_table._timer_is_started
+			self._timer_is_started = true --staticdata_table._timer_is_started
 			self._projectile_stack = ItemStack(staticdata_table._projectile_stack)
 			update_life_timer(self, dtime_s)
 		end,


### PR DESCRIPTION
**Описание PR:**

Исправление бага #1938 путём запуска таймера жизни стрелы на true по определению.

При этом я не стал удалять `_timer_is_started` вообще из кода потому что: а) Мне лень; б) Это долго тестировать (см. пункт а); в) Возможно для некоторых снарядов нужно будет ставить таймер в false (подробнее об этом в дополнении).

Важно: Я так же учел уже забагованные стрелы на сервере, поэтому все снаряды при загрузке в активную область должны будут **принудительно** запустить свой таймер (собственно, это то, что надо проверить в первую очередь).

PR идет хотфиксом!

**Рекомендации к тесту:**

- Проверить забагованные стрелы на сервере, они должны будут через 1.5 минуты максимум выпасть.

**Дополнительная информация:**

Касательно пункта В. Я видел на фотокарточке релиза упавшее дерево с воткнутым топором -- мне показалось это прикольным декором, так что возможно стоит подумать над тем, чтобы метательные топоры не запускали свой таймер вообще. Но тут много скользких моментов. Я решил, что минимальные изменения кода все-таки лучше, чем удаление поля отовсюду (к тому же, я не уверен, что будет, если из регистрации поле будет удалено, но у уже существующих стрел оно будет в БД)

fix #1938 