### PR TITLE
Правка вывода сообщений в чат

### DIFF
--- a/mods/lord/Game/server_message/init.lua
+++ b/mods/lord/Game/server_message/init.lua
@@ -15,17 +15,25 @@ local timer = 0
 minetest.register_globalstep(function(delta_time)
 	timer = timer + delta_time;
 	if (timer >= MESSAGE_PERIOD) and (minetest.get_connected_players()[1] ~= nil) then
+		local used_indices = {} --используется для хранения индексов уже выбранных ресурсов
 		local message = colorize('#0f0', '\n# Server: Оставайтесь на связи!')
 			.. ' (кликните по ссылке с Ctrl)\n'
 		message = message .. '+---------------------------------------------------------------------+\n'
 		message = message .. '|  ' ..
 			colorize('#ff0', 'Telegram:') ..' https://t.me/lord_server_ru                              |\n'
 		message = message .. '+---------------------------------------------------------------------+\n'
-		local random_resource = resources[math.random(#resources)]
-		message = message .. random_resource.title .. ': ' .. random_resource.url .. '\n'
-		random_resource = resources[math.random(#resources)]
-		message = message .. random_resource.title .. ': ' .. random_resource.url .. '\n'
+
+		for i = 1, 2 do
+			local index
+			-- Цикл ниже гарантирует, что индекс будет выбран заново, пока он не окажется уникальным среди уже использованных
+			repeat
+			index = math.random(#resources)
+			until not used_indices[index]
+			used_indices[index] = true
+			message = message .. resources[index].title .. ': ' .. resources[index].url .. '\n'
+		end
 		minetest.chat_send_all(message .. '\n')
 		timer = 0
+		used_indices = {}  -- Явная очистка таблицы после использования
 	end
 end)

--- a/mods/lord/Game/server_message/init.lua
+++ b/mods/lord/Game/server_message/init.lua
@@ -27,7 +27,7 @@ minetest.register_globalstep(function(delta_time)
 			local index
 			-- Цикл ниже гарантирует, что индекс будет выбран заново, пока он не окажется уникальным среди уже использованных
 			repeat
-			index = math.random(#resources)
+				index = math.random(#resources)
 			until not used_indices[index]
 			used_indices[index] = true
 			message = message .. resources[index].title .. ': ' .. resources[index].url .. '\n'

--- a/mods/lord/Game/server_message/init.lua
+++ b/mods/lord/Game/server_message/init.lua
@@ -34,6 +34,5 @@ minetest.register_globalstep(function(delta_time)
 		end
 		minetest.chat_send_all(message .. '\n')
 		timer = 0
-		used_indices = {}  -- Явная очистка таблицы после использования
 	end
 end)


### PR DESCRIPTION
**Описание PR:**

Fix #1831. Closes #1831

Проверено на `локальном`

Ошибка могла возникать из-за того, что при генерации двух случайных `resources` случайно выбирается одно и то же значение дважды, т.к. не запоминался предыдущий выбор.

Сейчас добавил таблицу индексов и цикл для выбора `resources` без повтора.

**Рекомендации к тесту:**

Последние две строки в приветственном сообщении не должны дублироваться.

***На тестовом***
Сообщения выводяться 1 раз в 30 мин
Набраться терпения и поймать хотя б 4-5 сообщений

***На локальном***
В модификации `server_message` в файле init.lua
Указать значение `MESSAGE_PERIOD` = 5
И в локальной игре ловить сообщения раз в пять секунд