### PR TITLE
Fix mobs jumps. Close #2094

### DIFF
--- a/mods/_various/mobs/api.lua
+++ b/mods/_various/mobs/api.lua
@@ -2350,7 +2350,7 @@ function mobs:register_mob(name, def)
 
 minetest.register_entity(name, {
 
-	stepheight = def.stepheight or 0.6,
+	stepheight = def.stepheight or 1.1,
 	name = name,
 	type = def.type,
 	attack_type = def.attack_type,


### PR DESCRIPTION
**Описание PR:**

A mob can now climb up 1 block without jumping

**Рекомендации к тесту:**

Посмотреть на то, как мобы в спокойном состоянии поднимаются по склонам холмов
Погонять агрессивных мобов по пересечённой местности
Проверить мобов у стен в 2 блока высотой. Чтоб не могли взобраться.

Для транспортных мобов ничего не изменилось,
у них и так была способность взбираться на 1 блок без прыжков.

**Дополнительная информация:**

Closes #2094
Possible closes #1987
