### PR TITLE
Fix double-jump for mobs. Closes #379

### DIFF
--- a/mods/_various/mobs/api.lua
+++ b/mods/_various/mobs/api.lua
@@ -543,7 +543,7 @@ local do_jump = function(self)
 	-- what is in front of mob?
 	nod = node_ok({
 		x = pos.x + dir_x,
-		y = pos.y + 0.5,
+		y = pos.y + 1,
 		z = pos.z + dir_z
 	})
 
@@ -561,7 +561,7 @@ local do_jump = function(self)
 
 		local v = self.object:get_velocity()
 
-		v.y = self.jump_height -- + 1
+		v.y = self.jump_height
 
 		set_animation(self, "jump") -- only when defined
 
@@ -2360,7 +2360,7 @@ minetest.register_entity(name, {
 	order = def.order or "",
 	on_die = def.on_die,
 	do_custom = def.do_custom,
-	jump_height = def.jump_height or 6,
+	jump_height = def.jump_height or 4,
 	drawtype = def.drawtype, -- DEPRECATED, use rotate instead
 	rotate = math.rad(def.rotate or 0), --  0=front, 90=side, 180=back, 270=side2
 	lifetimer = def.lifetimer or 180, -- 3 minutes

--- a/mods/_various/mobs/api.lua
+++ b/mods/_various/mobs/api.lua
@@ -502,7 +502,14 @@ end
 
 
 -- jump if facing a solid node (not fences or gates)
+local jump_cooldown = 1
+local can_jump = true
+
 local do_jump = function(self)
+    if not can_jump then
+        return false
+    end
+
 	if mob_is_dead(self) then
 		return
 	end
@@ -543,7 +550,7 @@ local do_jump = function(self)
 	-- what is in front of mob?
 	nod = node_ok({
 		x = pos.x + dir_x,
-		y = pos.y + 1,
+		y = pos.y + 0.5,
 		z = pos.z + dir_z
 	})
 
@@ -555,6 +562,7 @@ local do_jump = function(self)
 --print ("in front:", nod.name, pos.y + 0.5)
 
 	if (minetest.registered_items[nod.name].walkable
+	and not nod.name:find("walls")
 	and not nod.name:find("fence")
 	and not nod.name:find("gate"))
 	or self.walk_chance == 0 then
@@ -568,6 +576,12 @@ local do_jump = function(self)
 		self.object:set_velocity(v)
 
 		mob_sound(self, self.sounds.jump)
+
+		can_jump = false
+
+		minetest.after(jump_cooldown, function()
+			can_jump = true
+		end)
 
 		return true
 	end

--- a/mods/_various/mobs/api.lua
+++ b/mods/_various/mobs/api.lua
@@ -501,14 +501,10 @@ local do_env_damage = function(self)
 end
 
 
--- jump if facing a solid node (not fences or gates)
-local jump_cooldown = 1
-local can_jump = true
-
 local do_jump = function(self)
-    if not can_jump then
-        return false
-    end
+	if not self.can_jump then
+		return false
+	end
 
 	if mob_is_dead(self) then
 		return
@@ -577,10 +573,10 @@ local do_jump = function(self)
 
 		mob_sound(self, self.sounds.jump)
 
-		can_jump = false
+		self.can_jump = false
 
-		minetest.after(jump_cooldown, function()
-			can_jump = true
+		minetest.after(1, function()
+			self.can_jump = true
 		end)
 
 		return true
@@ -2101,6 +2097,12 @@ local mob_staticdata = function(self)
 		end
 	end
 
+	if self.can_jump ~= nil then
+		tmp.can_jump = self.can_jump
+	else
+		tmp.can_jump = true  -- default
+	end
+
 	--print('===== '..self.name..'\n'.. dump(tmp)..'\n=====\n')
 	return minetest.serialize(tmp)
 end
@@ -2216,6 +2218,9 @@ local mob_activate = function(self, staticdata, def)
 	self.collisionbox = colbox
 	self.visual_size = vis_size
 	self.standing_in = ""
+
+	-- Инициализация can_jump для старых мобов
+	self.can_jump = self.can_jump or true
 
 	-- set anything changed above
 	self.object:set_properties(self)


### PR DESCRIPTION
**Описание PR:**

Mobs will most often not be able to jump over 2 blocks

**Рекомендации к тесту:**

Погонять агрессивных мобов вокруг стены высотой в 2 блока
Они не должны на неё взбираться

Проверить ездовых мобов и морских.
Прыжки не должны выглядеть как-то аномально

**Дополнительная информация:**

Closes #379
