### PR TITLE
Submodule stainedglass switch to lord-server gitlab repo. #2003

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -81,9 +81,6 @@
 [submodule "mods/_various/mywalls"]
 	path = mods/_various/mywalls
 	url = https://github.com/minetest-mods/mywalls
-[submodule "mods/_various/stainedglass"]
-	path = mods/_various/stainedglass
-	url = https://gitlab.com/alerikaisattera/stainedglass.git
 [submodule "mods/_various/WorldEdit"]
 	path = mods/_various/WorldEdit
 	url = https://github.com/Uberi/Minetest-WorldEdit.git
@@ -97,3 +94,7 @@
 [submodule "mods/_various/j_mute"]
 	path = mods/_various/j_mute
 	url = https://github.com/Minetest-j45/j_mute
+[submodule "mods/_various/stainedglass"]
+	path = mods/_various/stainedglass
+	url = https://gitlab.com/lord-server/stainedglass.git
+	branch = lord


### PR DESCRIPTION
**Описание PR:**

Заменен сабмодуль stainedglass.
Автор оригинального мода(https://gitlab.com/alerikaisattera/stainedglass) не выходил на связь и не мержил новый MR где была добавлена локализация.
Модуль форкнули на https://gitlab.com/lord-server/stainedglass
Создали новую ветку lord и слили изменения в эту ветку.
Далее поправили url сабмодуля в .gitmodule
`git submodule add -b lord --force --name "mods/_various/stainedglass" https://gitlab.com/lord-server/stainedglass.git mods/_various/stainedglass`

**Рекомендации к тесту:**

**Дополнительная информация:**

#2003 
