### PR TITLE
Delete `do_custom_guard` func as unused. Closes #2141

### DIFF
--- a/mods/lord/Entities/lottmobs/src/animals/wild/warg.lua
+++ b/mods/lord/Entities/lottmobs/src/animals/wild/warg.lua
@@ -68,6 +68,5 @@ mobs:register_mob("lottmobs:warg", {
 	sounds               = {},
 	do_custom = function (self)
 		api.set_fear_height_by_state(self)
-		lottmobs.do_custom_guard()
 	end
 })


### PR DESCRIPTION
**Описание PR:**

Delete `do_custom_guard` func as unused

**Рекомендации к тесту:**

Не должно крашить сервер при наличии варгов в активной зоне
Команда  `/spawentity lottmobs:warg` в помощь

**Дополнительная информация:**

Closes #2141
