### PR TITLE
Set meta battle_stat, form, debug messages

### DIFF
--- a/mods/lord/Blocks/holding_node/src/holding_node/Form.lua
+++ b/mods/lord/Blocks/holding_node/src/holding_node/Form.lua
@@ -1,0 +1,32 @@
+local S = minetest.get_mod_translator()
+local spec = minetest.formspec
+
+
+--- @class holding_node.node.Form: base_classes.Form.Base
+--- @field node_position Position
+--- @field node_meta NodeMetaRef
+local Form = base_classes.Form:personal():for_node():extended({
+	NAME = 'holding_node:holding_node_config',
+})
+
+--- @private
+function Form:get_spec()
+	local str_pos = self.node_position.x .. ',' .. self.node_position.y .. ',' .. self.node_position.z
+
+	return ''
+		.. spec.size(8,9)
+		.. spec.field(1, 1, 3, 1, 'input_name',S('Name'), '')
+		.. spec.button_exit(1, 2, 3, 1, 'save', S('Save'))
+		.. spec.list('nodemeta:' .. str_pos, 'reward', 1, 3, 4, 1)
+end
+
+function Form:handle(fields)
+	if fields.input_name and fields.save then
+		if self.node_meta then
+			self.node_meta:set_string('name', fields.input_name)
+		end
+	end
+end
+
+
+return Form:register()

--- a/mods/lord/Blocks/holding_node/src/holding_node/Form.lua
+++ b/mods/lord/Blocks/holding_node/src/holding_node/Form.lua
@@ -10,6 +10,7 @@ local Form = base_classes.Form:personal():for_node():extended({
 })
 
 --- @private
+--- @return string
 function Form:get_spec()
 	local str_pos = self.node_position.x .. ',' .. self.node_position.y .. ',' .. self.node_position.z
 
@@ -20,6 +21,7 @@ function Form:get_spec()
 		.. spec.list('nodemeta:' .. str_pos, 'reward', 1, 3, 4, 1)
 end
 
+--- @param fields table
 function Form:handle(fields)
 	if fields.input_name and fields.save then
 		if self.node_meta then

--- a/mods/lord/Blocks/holding_node/src/holding_node/node.lua
+++ b/mods/lord/Blocks/holding_node/src/holding_node/node.lua
@@ -24,7 +24,9 @@ local definition = {
 				"field[1,1;3,1;name;Name;]" ..
 				"button_exit[1,2.5;3,1;exit;Save]")
 
-		-- Отладочное сообщение
+		minetest.show_formspec(placer:get_player_name(), "holding_block:holding_block", meta:get_string("formspec"))
+
+		-- debug formspec
 		minetest.log("action", "Formspec set: " .. meta:get_string("formspec"))
 	end,
 	on_receive_fields = function(pos, formname, fields, player)
@@ -39,17 +41,28 @@ local definition = {
 	on_punch = function(pos, node, player, pointed_thing)
 		local meta = minetest.get_meta(pos)
 
-		-- *** BATTLE STAT *** starting
+		-- BATTLE STAT: starting
+
 		local battle_stat = minetest.deserialize(meta:get_string('battle_stat')) or {}
 		local clan_id = clans.clan_get_by_player(player).name
+
 		-- set meta to table
-		table.insert(battle_stat, {clan = clan_id, time = os.time()})
+		if clan_id then
+			table.insert(battle_stat, {clan = clan_id, time = os.time()})
+		else
+			minetest.log("warning", "Clan ID is nil, not adding to battle_stat.")
+		end
 
 		-- serialize table battle_stat to meta as string
 		meta:set_string('battle_stat', minetest.serialize(battle_stat))
-		-- *** BATTLE STAT *** ending
 
-		meta:set_string ('captured_by_clan', clan_id)
+		-- BATTLE STAT: ending
+
+		if clan_id then
+			meta:set_string ('captured_by_clan', clan_id)
+		else
+			minetest.log("warning", "Clan ID is nil, not adding to captured_by_clan.")
+		end
 
 		-- debug meta
 		minetest.log("action", "Meta is: " .. (dump(meta:to_table())))

--- a/mods/lord/Blocks/holding_node/src/holding_node/node.lua
+++ b/mods/lord/Blocks/holding_node/src/holding_node/node.lua
@@ -71,7 +71,7 @@ local definition = {
 		local battle_stat = minetest.deserialize(meta:get_string('battle_stat')) or {}
 		local current_time = os.time()
 
-		battle_stat[clan.name] = current_time
+		battle_stat[clan.name] = 0
 
 		-- обновить метаданные ноды
 		meta:set_string('battle_stat', minetest.serialize(battle_stat))

--- a/mods/lord/Blocks/holding_node/src/holding_node/node.lua
+++ b/mods/lord/Blocks/holding_node/src/holding_node/node.lua
@@ -13,7 +13,49 @@ local definition = {
 		meta:set_string ('captured_by_clan', S('Nobody'))
 		meta:set_int    ('captured_at', 0)
 		meta:set_int    ('reward_gived_at', 0)
+		meta:set_string ('battle_stat', minetest.serialize({}))
 	end,
+
+	after_place_node = function(pos, placer)
+		local meta = minetest.get_meta(pos)
+		meta:set_string("formspec",
+				"formspec_version[4]" ..
+				"size[5,4]" ..
+				"field[1,1;3,1;name;Name;]" ..
+				"button_exit[1,2.5;3,1;exit;Save]")
+
+		-- Отладочное сообщение
+		minetest.log("action", "Formspec set: " .. meta:get_string("formspec"))
+	end,
+	on_receive_fields = function(pos, formname, fields, player)
+		local meta = minetest.get_meta(pos)
+
+		if fields.name then
+			meta:set_string('name', fields.name) -- Обновляем метаданную name
+		end
+	end,
+
+	--- @param player Player
+	on_punch = function(pos, node, player, pointed_thing)
+		local meta = minetest.get_meta(pos)
+
+		-- *** BATTLE STAT *** starting
+		local battle_stat = minetest.deserialize(meta:get_string('battle_stat')) or {}
+		local clan_id = clans.clan_get_by_player(player).name
+		-- set meta to table
+		table.insert(battle_stat, {clan = clan_id, time = os.time()})
+
+		-- serialize table battle_stat to meta as string
+		meta:set_string('battle_stat', minetest.serialize(battle_stat))
+		-- *** BATTLE STAT *** ending
+
+		meta:set_string ('captured_by_clan', clan_id)
+
+		-- debug meta
+		minetest.log("action", "Meta is: " .. (dump(meta:to_table())))
+
+
+	end
 }
 
 


### PR DESCRIPTION
**Описание PR:**

Дополнил метаданные таблицей `battle_stat`

Для теста: при ударе по ноде в таблицу пишется клан и время удара
В рабочей версии: в таблицу будут записываться баллы

Добавил начальную форму для смены имени ноды

**Рекомендации к тесту:**
Уронить сервер формой или использованием ноды
Получить привилегии при установке или использовании ноды

**Дополнительная информация:**

Closes #2125 
Closes #2126 