### PR TITLE
Add debug section for `on_punchplayer`. Fix `nil` checks. Closes #2161

### DIFF
--- a/mods/lord/Blocks/protector_lott/init.lua
+++ b/mods/lord/Blocks/protector_lott/init.lua
@@ -407,21 +407,14 @@ if minetest.settings:get_bool("enable_pvp") and protector.pvp then
 
 		minetest.register_on_punchplayer(
 		function(player, hitter, time_from_last_punch, tool_capabilities, dir, damage)
-			-- debug section start
-			local debug_force_nil_hitter = false
-
-			if debug_force_nil_hitter then
-				hitter = nil
-			end
-			-- debug section end
 
 			if not player or not hitter then
 				minetest.log("warning", "[Protector] on_punchplayer called with nil objects")
-				return true -- Запрещаем обработку удара
+				return true -- Запретить обработку удара если функция вызвана с nil аргументами
 			end
 
 			if not hitter:is_player() then
-				return false -- Разрешаем удар от не-игроков (мобов и т.д.)
+				return false -- Разрешить обработку удара от не-игроков (мобов и т.д.)
 			end
 
 			-- no pvp at spawn area

--- a/mods/lord/Blocks/protector_lott/init.lua
+++ b/mods/lord/Blocks/protector_lott/init.lua
@@ -407,13 +407,21 @@ if minetest.settings:get_bool("enable_pvp") and protector.pvp then
 
 		minetest.register_on_punchplayer(
 		function(player, hitter, time_from_last_punch, tool_capabilities, dir, damage)
+			-- debug section start
+			local debug_force_nil_hitter = false
+
+			if debug_force_nil_hitter then
+				hitter = nil
+			end
+			-- debug section end
 
 			if not player or not hitter then
 				minetest.log("warning", "[Protector] on_punchplayer called with nil objects")
+				return true -- Запрещаем обработку удара
 			end
 
 			if not hitter:is_player() then
-				return false
+				return false -- Разрешаем удар от не-игроков (мобов и т.д.)
 			end
 
 			-- no pvp at spawn area
@@ -427,11 +435,7 @@ if minetest.settings:get_bool("enable_pvp") and protector.pvp then
 				return true
 			end
 
-			if minetest.is_protected(pos, hitter:get_player_name()) then
-				return true
-			else
-				return false
-			end
+			return minetest.is_protected(pos, hitter:get_player_name())
 
 		end)
 	else


### PR DESCRIPTION
**Описание PR:**

В функцию `on_punchplayer` добавил секцию для дебага на время тестов.

Согласно рекомендациям бота Deepseek, внёс правки в проверку на значения `nil` - теперь удар от снаряда не обрабатывается если стреляющий исчезает с сервера до момента нанесения урона снарядом.

**Рекомендации к тесту:**

**Код предложил бот** - нужна тщательная проверка

Протестировать усердно нанесение урона в зоне действия протектов.

Протестировать случаи когда источник урона: моб или игрок исчезают до того, как снаряд ударит по игроку.

После успешных тестов на полигоне, можно удалить секцию дебага из функции `on_punchplayer`

**Дополнительная информация:**

Closes #2161 
