### PR TITLE
Balancing the elven sword. #2185

### DIFF
--- a/mods/lord/Entities/lottmobs/src/racial/others/dead_man.lua
+++ b/mods/lord/Entities/lottmobs/src/racial/others/dead_man.lua
@@ -18,7 +18,7 @@ mobs:register_mob("lottmobs:dead_men", {
 	run_velocity = 4,
 	damage = 8,
 	damage_type = damage.Type.SOUL,
-	armor = {soul = 100, immortal = 1},
+	armor = {soul = 200, immortal = 1},
 	water_damage = 0,
 	lava_damage = 0,
 	light_damage = 1,

--- a/mods/lord/Tools/tools/src/racial.lua
+++ b/mods/lord/Tools/tools/src/racial.lua
@@ -7,7 +7,7 @@ minetest.register_tool('tools:sword_elven', {
 	tool_capabilities = {
 		max_drop_level      = 2,
 		groupcaps           = { snappy = { times = { [1] = 1.60, [2] = 1.30, [3] = 0.90 }, uses = 50, maxlevel = 3 }, },
-		damage_groups       = { soul = 8, fleshy = 6.2 },
+		damage_groups       = { soul = 4, fleshy = 6.2 },
 		full_punch_interval = 1,
 	},
 	groups            = { bronze_item = 1, forbidden = 1 },


### PR DESCRIPTION
In PvP, the elven sword kills too fast.
Reduced soul damage for player.
Saved damage for dead_men.

**Описание PR:**

[<Ясное и краткое описание PR.>]

**Рекомендации к тесту:**

Проверить урон на игроке. Должно выбивать 2 сердечка при наличии эльфийского кольца.
Проверить урон на призраке. Должны убиваться за два удара с интевалом в 1 сек. или непрерывным за 1.9 сек.

**Дополнительная информация:**

#2185

[<Если PR имеет связанное issue, занесите его номер сюда.>]
