### PR TITLE
Music Nodes: change tooltips styles. Closes #2255

### DIFF
--- a/mods/lord/Blocks/Music/music_instruments/locale/music_instruments.ru.tr
+++ b/mods/lord/Blocks/Music/music_instruments/locale/music_instruments.ru.tr
@@ -25,9 +25,8 @@ if approached with enthusiasm.=если подойти с энтузиазмом
 
 Note:=Нота:
 
-Musical instrument base=Основа музыкального инструмента
+Musical instrument base=Корпус музыкального инструмента
 A stone plucked from the embrace of subterranean horrors=Камень, вырванный из объятий подземных ужасов
 and a tree liberated from the elves=и дерево, позаимствованное у эльфов
 They are now the basis for melodies=Теперь они — основа для мелодий
 that can melt hearts...=способных растопить сердца...
-or exorcise nazguls=или изгнать назгулов

--- a/mods/lord/Blocks/Music/music_instruments/locale/music_instruments.ru.tr
+++ b/mods/lord/Blocks/Music/music_instruments/locale/music_instruments.ru.tr
@@ -9,23 +9,25 @@ and dedicated labour.=и самоотверженного труда.
 
 Kalimba=Калимба
 
-The kalimba is a magical instrument=Калимба - волшебный инструмент,
+A kalimba=Калимба
+Is a magical instrument=Это волшебный инструмент,
 that can turn even the most hopeless=способный превратить даже самые безнадежные
 musical attempts=музыкальные попытки
 into something resembling a melody.=в нечто, напоминающее мелодию
 
 Metallophone=Металлофон
 
-The metallophone can sound=Металлофон может звучать
-like an angelic choir,=как ангельский хор,
+A metallophone=Металлофон
+It can sound like an angelic choir,=Может звучать, как ангельский хор,
 if struck gently,=если ударить по нему нежно,
 or like a china shop fight=или как бой в посудной лавке,
 if approached with enthusiasm.=если подойти с энтузиазмом.
 
 Note:=Нота:
 
+Musical instrument base=Основа музыкального инструмента
 A stone plucked from the embrace of subterranean horrors=Камень, вырванный из объятий подземных ужасов
 and a tree liberated from the elves=и дерево, позаимствованное у эльфов
 They are now the basis for melodies=Теперь они — основа для мелодий
 that can melt hearts...=способных растопить сердца...
-or exorcise nazguls=или изгонять назгулов
+or exorcise nazguls=или изгнать назгулов

--- a/mods/lord/Blocks/Music/music_instruments/src/music_instruments/music_base.lua
+++ b/mods/lord/Blocks/Music/music_instruments/src/music_instruments/music_base.lua
@@ -1,22 +1,16 @@
-local S = minetest.get_mod_translator()
+local config = require('music_instruments.music_node.config')
+local def = config.base
+
 
 local function register_base()
 	minetest.register_node('music_instruments:base', {
-		description =   S('Musical instrument base') .. '\n' ..
-						S('A stone plucked from the embrace of subterranean horrors') .. '\n' ..
-						S('and a tree liberated from the elves') .. '\n' ..
-						S('They are now the basis for melodies') .. '\n' ..
-						S('that can melt hearts...') .. '\n' ..
-						S('or exorcise nazguls'),
-		drawtype = 'mesh',
-		mesh = 'music_instruments_base.obj',
-		tiles = {
-			'lord_rocks_peridotite.png',
-			'lord_trees_yavannamire_tree.png',
-			'lord_trees_yavannamire_tree_top.png',
-		},
-		paramtype = "light",
-		paramtype2 = "facedir",
+		description = def.title,
+		_tt_help = def.description and minetest.colorize('#aaa',  '\n' .. def.description),
+		drawtype = def.drawtype,
+		mesh = def.mesh,
+		tiles = def.tiles,
+		paramtype = def.paramtype,
+		paramtype2 = def.paramtype2,
 		groups = { choppy = 2, forbidden = 1 },
 	})
 

--- a/mods/lord/Blocks/Music/music_instruments/src/music_instruments/music_node.lua
+++ b/mods/lord/Blocks/Music/music_instruments/src/music_instruments/music_node.lua
@@ -5,7 +5,8 @@ local config = require('music_instruments.music_node.config')
 local function register_instruments()
 	for instrument, def in pairs(config.instruments) do
 		minetest.register_node('music_instruments:' .. instrument, {
-			description = def.description,
+			description = def.title,
+			_tt_help = def.description and minetest.colorize('#aaa',  '\n' .. def.description),
 			drawtype = def.drawtype,
 			mesh = def.mesh,
 			tiles = def.tiles,

--- a/mods/lord/Blocks/Music/music_instruments/src/music_instruments/music_node/config.lua
+++ b/mods/lord/Blocks/Music/music_instruments/src/music_instruments/music_node/config.lua
@@ -112,8 +112,7 @@ local base = {
 	description =   S('A stone plucked from the embrace of subterranean horrors') .. '\n' ..
 					S('and a tree liberated from the elves') .. '\n' ..
 					S('They are now the basis for melodies') .. '\n' ..
-					S('that can melt hearts...') .. '\n' ..
-					S('or exorcise nazguls'),
+					S('that can melt hearts...'),
 	drawtype = 'mesh',
 	mesh = 'music_instruments_base.obj',
 	tiles = {

--- a/mods/lord/Blocks/Music/music_instruments/src/music_instruments/music_node/config.lua
+++ b/mods/lord/Blocks/Music/music_instruments/src/music_instruments/music_node/config.lua
@@ -13,7 +13,8 @@ local S = minetest.get_mod_translator()
 local instruments = {
 	kalimba = {
 		name = S('Kalimba'),
-		description =   S('The kalimba is a magical instrument') .. '\n' ..
+		title = S('A kalimba'),
+		description =   S('Is a magical instrument') .. '\n' ..
 						S('that can turn even the most hopeless') .. '\n' ..
 						S('musical attempts') .. '\n' ..
 						S('into something resembling a melody.'),
@@ -68,8 +69,8 @@ local instruments = {
 
 	metallophone = {
 		name = S('Metallophone'),
-		description =   S('The metallophone can sound') .. '\n' ..
-						S('like an angelic choir,') .. '\n' ..
+		title = S('A metallophone'),
+		description =   S('It can sound like an angelic choir,') .. '\n' ..
 						S('if struck gently,') .. '\n' ..
 						S('or like a china shop fight') .. '\n' ..
 						S('if approached with enthusiasm.'),
@@ -106,7 +107,27 @@ local instruments = {
 	},
 }
 
+local base = {
+	title = S('Musical instrument base') ,
+	description =   S('A stone plucked from the embrace of subterranean horrors') .. '\n' ..
+					S('and a tree liberated from the elves') .. '\n' ..
+					S('They are now the basis for melodies') .. '\n' ..
+					S('that can melt hearts...') .. '\n' ..
+					S('or exorcise nazguls'),
+	drawtype = 'mesh',
+	mesh = 'music_instruments_base.obj',
+	tiles = {
+		'lord_rocks_peridotite.png',
+		'lord_trees_yavannamire_tree.png',
+		'lord_trees_yavannamire_tree_top.png',
+	},
+	paramtype = "light",
+	paramtype2 = "facedir",
+	groups = { choppy = 2, forbidden = 1 },
+}
+
 
 return {
 	instruments = instruments,
+	base = base,
 }


### PR DESCRIPTION


**Описание PR:**

Изменил стиль описаний музыкальных блоков
Перенёс описание ноды `music_base` в конфиг

**Рекомендации к тесту:**

В описании должен быть белый заголовок, отступ и описание блока
Полностью проверить `music_instruments:base`

**Дополнительная информация:**

Closes #2255
