### PR TITLE
Changed the anvil inventory listring to `main-craft-main-result-main`

### DIFF
--- a/mods/lord/Blocks/ArtisanBenches/anvil/src/anvil/Form.lua
+++ b/mods/lord/Blocks/ArtisanBenches/anvil/src/anvil/Form.lua
@@ -22,7 +22,10 @@ function Form:get_spec()
 		'list[current_player;main;0,6.08;8,3;8]' ..
 
 		'listring[current_player;main]' ..
-		'listring[detached:'..inventory_id..';craft]'
+		'listring[detached:'..inventory_id..';craft]' ..
+		'listring[current_player;main]' ..
+		'listring[detached:'..inventory_id..';craft_result]' ..
+		'listring[current_player;main]'
 end
 
 --- @private


### PR DESCRIPTION
**Описание PR:**

Данный PR изменяет цикл перемещения предметов наковальни (перемещение предметов с зажатым shift) с цикла `инвентарь игрока <-> крафтовая сетка` на два цикла `инвентарь игрока -> крафтовая сетка -> инвентарь игрока` и `результат крафта -> инвентарь игрока`

Это необходимо для того, чтобы можно было производить крафт с зажатым `shift` - это экономит время, перемещая результат крафта сразу в инвентарь игрока.

**Рекомендации к тесту:**

- Проверить, что предметы попадают в инвентарь наковальни, если кликать по ним ЛКМ в инвентаре игрока с зажатым шифтом
- Проверить, что результат крафта попадает (то есть крафт происходит) в инвентарь игрока, если кликать по нему ЛКМ

**Дополнительная информация:**

Отсутствует