### PR TITLE
Disable transparency to fix blend glitch. Close #2345

### DIFF
--- a/mods/lord/Blocks/ArtisanBenches/cauldron/src/cauldron.lua
+++ b/mods/lord/Blocks/ArtisanBenches/cauldron/src/cauldron.lua
@@ -9,7 +9,6 @@ local common_definition = {
 		'benches_cauldron_top.png', 'benches_cauldron_side.png', 'benches_cauldron_side.png',
 		'benches_cauldron_side.png', 'benches_cauldron_side.png', 'benches_cauldron_side.png',
 	},
-	use_texture_alpha = 'blend',
 	paramtype         = 'light',
 	paramtype2        = 'facedir',
 	groups            = { cracky = 1 },


### PR DESCRIPTION
**Описание PR:**
Выключил обработку прозрачности текстуры воды в ноде
На текущий момент она работает глючно
<img width="1620" height="877" alt="изображение" src="https://github.com/user-attachments/assets/0793b299-dcfb-4ce3-afa0-91d5c43f90bb" />

**Рекомендации к тесту:**
Стенки котла не должны просвечивать, если он заполнен