### PR TITLE
Now broken crafts are definitely removed from the register. Close #1993

### DIFF
--- a/mods/lord/_overwrites/various/painting/init.lua
+++ b/mods/lord/_overwrites/various/painting/init.lua
@@ -11,8 +11,8 @@ for _, dye in ipairs(dye.dyes) do
 		}
 	})
 
-	-- TODO: remove after fixing sfence/painting#15 issue
-	minetest.clear_craft({output = "painting"})
+	-- Removing crafts with hemp oil that we don't have.
+	minetest.clear_craft({output = "painting:oil_color_"..color})
 
 	minetest.register_craft{
 		output = "painting:oil_color_"..color,


### PR DESCRIPTION
**Описание PR:**

Исправил ошибку #1993 путем поправки в вызове `minetest.clear_craft`

**Рекомендации к тесту:**

- Убедиться, что у крафтов маслянных красок нет крафтов с `unknow_item`

**Дополнительная информация:**

По-идее эта ошибка не должна была возникать, т.к. вы сообщали о ней автору мода `paintings` (https://github.com/sfence/painting/issues/15) и он её исправил. Стянули ли вы его фикс или нет -- я так и не понял, однако его фикс **нам не подходит**, поскольку его мод определяет, существует ли конопляное масло и если его нет (наш случай) маслянные краски **не регистрируются вообще**.

Таким образом если апдейтнуть мод на последную версию (я проверял) маслянные краски в игре в принципе отсутствуют как предмет