### PR TITLE
Fix protection sigh placement failure. LG-2172. Closes #2396

### DIFF
--- a/mods/lord/Blocks/protector_lott/init.lua
+++ b/mods/lord/Blocks/protector_lott/init.lua
@@ -288,7 +288,7 @@ function minetest.item_place(itemstack, placer, pointed_thing, param2)
 			local pos  = pointed_thing.under
 			local can_dig_result = protector.can_dig(protector.radius * 2, pos, user, true, 3)
 			if can_dig_result ~= nil then
-				if not placer_can_dig then
+				if not can_dig_result then
 					minetest.chat_send_player(user, S("Overlaps into another protected area!"))
 
 					return protector.old_node_place(itemstack, placer, pos, param2)

--- a/mods/lord/Blocks/protector_lott/init.lua
+++ b/mods/lord/Blocks/protector_lott/init.lua
@@ -286,10 +286,13 @@ function minetest.item_place(itemstack, placer, pointed_thing, param2)
 	    if item_definition.groups and item_definition.groups.protector then
 			local user = placer:get_player_name()
 			local pos  = pointed_thing.under
-			if not protector.can_dig(protector.radius * 2, pos, user, true, 3) then
-				minetest.chat_send_player(user, S("Overlaps into another protected area!"))
+			local can_dig_result = protector.can_dig(protector.radius * 2, pos, user, true, 3)
+			if can_dig_result ~= nil then
+				if not placer_can_dig then
+					minetest.chat_send_player(user, S("Overlaps into another protected area!"))
 
-				return protector.old_node_place(itemstack, placer, pos, param2)
+					return protector.old_node_place(itemstack, placer, pos, param2)
+				end
 			end
 	    end
 	end


### PR DESCRIPTION
**Описание PR:**

Добавляется ранее пропущенная в одном месте проверка возвращаемого значения `nil` функцией `protector.can_dig()`.

**Рекомендации к тесту:**

Размещать знаки защиты `protector_lott:protect2`, взаимодействовать с блоками, попадающими в его область защиты, взаимодействовать с блоками, которые не попадают в неё, размещать знаки защиты в этой области и на пересечениях областей, а также там, где таких областей нет.

**Дополнительная информация:**

Исправляет https://github.com/lord-server/lord/issues/2396
